### PR TITLE
Add machinist assignment and printable order view

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -113,6 +113,21 @@
     scrollbar-width: thin;
     scrollbar-color: hsl(var(--border)) transparent;
   }
+
+  @media print {
+    body {
+      background: #ffffff !important;
+      color: #000000 !important;
+      background-image: none !important;
+    }
+    header,
+    footer {
+      display: none !important;
+    }
+    main {
+      padding: 0 !important;
+    }
+  }
 }
 
 @layer utilities {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,7 +15,7 @@ const roboto = Roboto({
 
 export const metadata = {
   title: 'ShopApp',
-  description: 'Machine shop order tracking',
+  description: 'Sterling Tool and Die order tracking',
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
@@ -29,7 +29,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
                 SA
               </div>
               <div className="hidden sm:block">
-                <p className="text-[0.65rem] uppercase tracking-[0.35em] text-muted-foreground">Machine Shop</p>
+                <p className="text-[0.65rem] uppercase tracking-[0.35em] text-muted-foreground">Sterling Tool and Die</p>
                 <h1 className="text-xl font-semibold text-foreground">ShopApp</h1>
               </div>
             </Link>
@@ -51,7 +51,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
             <div className="container py-10">{children}</div>
           </main>
           <footer className="border-t border-border/60 bg-background/80 py-6 text-center text-xs uppercase tracking-[0.3em] text-muted-foreground">
-            Demo • built with ❤️
+            Sterling Tool and Die • built with ❤️
           </footer>
         </div>
       </body>

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -9,6 +9,7 @@ import {
   Building2,
   ClipboardList,
   Package2,
+  Printer,
   StickyNote,
 } from 'lucide-react';
 
@@ -54,6 +55,10 @@ export default function OrderDetailPage() {
   const [error, setError] = useState<string | null>(null);
   const [toggling, setToggling] = useState<string | null>(null);
   const [noteText, setNoteText] = useState('');
+  const openPrint = React.useCallback(() => {
+    if (!id) return;
+    window.open(`/orders/${id}/print`, '_blank', 'noopener,noreferrer');
+  }, [id]);
 
   async function load() {
     if (!id) return;
@@ -157,7 +162,16 @@ export default function OrderDetailPage() {
             Customer-facing details, shop routing, and production notes for this work order.
           </p>
         </div>
-        <Badge className={statusColor(item.status)}>{item.status.replace(/_/g, ' ')}</Badge>
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            onClick={openPrint}
+            className="rounded-full bg-primary/90 text-primary-foreground shadow-md shadow-primary/30 hover:bg-primary"
+          >
+            <Printer className="mr-2 h-4 w-4" /> Pring
+          </Button>
+          <Badge className={statusColor(item.status)}>{item.status.replace(/_/g, ' ')}</Badge>
+        </div>
       </div>
 
       <div className="grid gap-6 lg:grid-cols-[320px_1fr]">

--- a/src/app/orders/[id]/print/page.tsx
+++ b/src/app/orders/[id]/print/page.tsx
@@ -1,0 +1,209 @@
+import { format } from 'date-fns';
+import { redirect, notFound } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+import { prisma } from '@/lib/prisma';
+
+function formatDate(input?: string | Date | null, withTime = false) {
+  if (!input) return '-';
+  const date = input instanceof Date ? input : new Date(input);
+  if (Number.isNaN(date.getTime())) return '-';
+  return format(date, withTime ? 'PPpp' : 'PP');
+}
+
+export default async function OrderPrintPage({ params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect(`/auth/signin?callbackUrl=/orders/${params.id}/print`);
+  }
+
+  const order = await prisma.order.findUnique({
+    where: { id: params.id },
+    include: {
+      customer: true,
+      assignedMachinist: true,
+      vendor: true,
+      parts: { include: { material: true } },
+      checklist: { include: { checklistItem: true } },
+      attachments: true,
+      notes: { include: { user: true }, orderBy: { createdAt: 'asc' } },
+    },
+  });
+
+  if (!order) {
+    notFound();
+  }
+
+  return (
+    <div className="mx-auto max-w-4xl space-y-8 bg-white p-8 text-sm text-black print:p-6">
+      <header className="flex flex-col gap-4 border-b border-gray-300 pb-4 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Sterling Tool and Die</h1>
+          <p className="text-base font-medium">ShopApp Work Order</p>
+        </div>
+        <div className="text-right">
+          <p className="text-xl font-semibold">Order #{order.orderNumber}</p>
+          <p className="text-gray-600">Status: {order.status.replace(/_/g, ' ')}</p>
+          <p className="text-gray-600">Due: {formatDate(order.dueDate)}</p>
+        </div>
+      </header>
+
+      <section className="grid gap-4 border border-gray-300 p-4">
+        <h2 className="text-lg font-semibold">Job summary</h2>
+        <div className="grid gap-2 md:grid-cols-2">
+          <div>
+            <p className="text-xs uppercase text-gray-500">Received</p>
+            <p className="font-medium">{formatDate(order.receivedDate)}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Priority</p>
+            <p className="font-medium">{order.priority}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Machinist</p>
+            <p className="font-medium">
+              {order.assignedMachinist?.name ?? order.assignedMachinist?.email ?? 'Unassigned'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">PO Number</p>
+            <p className="font-medium">{order.poNumber ?? '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Vendor</p>
+            <p className="font-medium">{order.vendor?.name ?? '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Material status</p>
+            <p className="font-medium">
+              {order.materialNeeded ? (order.materialOrdered ? 'Ordered / On hand' : 'Needed') : 'Not required'}
+            </p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Model included</p>
+            <p className="font-medium">{order.modelIncluded ? 'Yes' : 'No'}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 border border-gray-300 p-4">
+        <h2 className="text-lg font-semibold">Customer</h2>
+        <div className="grid gap-2 md:grid-cols-2">
+          <div>
+            <p className="text-xs uppercase text-gray-500">Name</p>
+            <p className="font-medium">{order.customer?.name ?? '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Contact</p>
+            <p className="font-medium">{order.customer?.contact ?? '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Phone</p>
+            <p className="font-medium">{order.customer?.phone ?? '—'}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-gray-500">Email</p>
+            <p className="font-medium">{order.customer?.email ?? '—'}</p>
+          </div>
+          <div className="md:col-span-2">
+            <p className="text-xs uppercase text-gray-500">Address</p>
+            <p className="whitespace-pre-line font-medium">{order.customer?.address ?? '—'}</p>
+          </div>
+        </div>
+      </section>
+
+      <section className="grid gap-4 border border-gray-300 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-lg font-semibold">Parts</h2>
+          <p className="text-xs uppercase text-gray-500">Total parts: {order.parts.length}</p>
+        </div>
+        <table className="w-full table-fixed border-collapse">
+          <thead>
+            <tr className="border-b border-gray-300 text-left">
+              <th className="w-1/4 py-2 text-xs uppercase text-gray-500">Part #</th>
+              <th className="w-1/6 py-2 text-xs uppercase text-gray-500">Qty</th>
+              <th className="w-1/4 py-2 text-xs uppercase text-gray-500">Material</th>
+              <th className="py-2 text-xs uppercase text-gray-500">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {order.parts.map((part) => (
+              <tr key={part.id} className="border-b border-gray-200 align-top">
+                <td className="py-2 font-medium">{part.partNumber}</td>
+                <td className="py-2">{part.quantity}</td>
+                <td className="py-2">{part.material?.name ?? '—'}</td>
+                <td className="py-2">{part.notes ?? '—'}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="grid gap-4 border border-gray-300 p-4">
+        <h2 className="text-lg font-semibold">Checklist</h2>
+        {order.checklist.length ? (
+          <ul className="space-y-2">
+            {order.checklist.map((item) => (
+              <li key={item.id} className="flex items-center justify-between border border-gray-200 px-3 py-2">
+                <span className="font-medium">{item.checklistItem?.label ?? 'Checklist item'}</span>
+                <span className="text-xs uppercase text-gray-500">
+                  Updated {formatDate(item.updatedAt, true)}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-600">No checklist items recorded for this order.</p>
+        )}
+      </section>
+
+      <section className="grid gap-4 border border-gray-300 p-4">
+        <h2 className="text-lg font-semibold">Attachments</h2>
+        {order.attachments.length ? (
+          <table className="w-full table-fixed border-collapse">
+            <thead>
+              <tr className="border-b border-gray-300 text-left">
+                <th className="w-1/3 py-2 text-xs uppercase text-gray-500">Label</th>
+                <th className="w-1/3 py-2 text-xs uppercase text-gray-500">Type</th>
+                <th className="py-2 text-xs uppercase text-gray-500">Link</th>
+              </tr>
+            </thead>
+            <tbody>
+              {order.attachments.map((att) => (
+                <tr key={att.id} className="border-b border-gray-200 align-top">
+                  <td className="py-2 font-medium">{att.label ?? 'Attachment'}</td>
+                  <td className="py-2">{att.mimeType ?? '—'}</td>
+                  <td className="py-2 break-words text-blue-700">
+                    {att.url}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        ) : (
+          <p className="text-sm text-gray-600">No attachments on file.</p>
+        )}
+      </section>
+
+      <section className="grid gap-4 border border-gray-300 p-4">
+        <h2 className="text-lg font-semibold">Notes</h2>
+        {order.notes.length ? (
+          <ul className="space-y-3">
+            {order.notes.map((note) => (
+              <li key={note.id} className="border border-gray-200 p-3">
+                <div className="flex items-center justify-between text-xs uppercase text-gray-500">
+                  <span>{note.user?.name ?? 'Unknown'}</span>
+                  <span>{formatDate(note.createdAt, true)}</span>
+                </div>
+                <p className="mt-2 whitespace-pre-line text-sm text-gray-800">{note.content}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-600">No notes recorded.</p>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -6,6 +6,7 @@ import { usePathname } from 'next/navigation';
 import { cn } from '@/lib/utils';
 
 const links = [
+  { href: '/', label: 'Shop Floor Intelligence' },
   { href: '/orders', label: 'Orders' },
   { href: '/orders/new', label: 'New Order' },
   { href: '/admin/users', label: 'Admin' },


### PR DESCRIPTION
## Summary
- add Sterling Tool and Die branding and expose the Shop Floor Intelligence dashboard in the navigation
- allow selecting a machinist when creating a new order and offer quick navigation after submission
- add a dedicated printable order view with a "Pring" button and global print styling tweaks

## Testing
- npm run build *(fails: Next.js type check cannot resolve PrismaClient in prisma/seed.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d3eeb3996c832784786c163877edef