### PR TITLE
Fix machinist workload aggregation on home dashboard

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -91,10 +91,10 @@ export default async function Home() {
   }, {} as Record<string, number>);
 
   const machinistWorkload = activeOrders.reduce((acc, order) => {
-    if (!order.assignedMachinist) return acc;
-    const id = order.assignedMachinist.id;
+    const id = order.assignedMachinistId;
+    if (!id) return acc;
     if (!acc[id]) {
-      acc[id] = { name: order.assignedMachinist.name ?? 'Unassigned', count: 0 };
+      acc[id] = { name: order.assignedMachinist?.name ?? 'Unassigned', count: 0 };
     }
     acc[id].count += 1;
     return acc;


### PR DESCRIPTION
## Summary
- ensure the machinist workload widget groups active orders by the assigned machinist id so multiple assignees appear
- keep displaying machinist names from the related record while ignoring unassigned orders

## Testing
- pnpm run build *(fails: existing duplicate `router` definitions in src/app/orders/new/page.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68d4187afcbc8327ba4360fb6b80763a