### PR TITLE
Allow machinist access to shared lists and update profile metrics

### DIFF
--- a/src/app/api/admin/customers/route.ts
+++ b/src/app/api/admin/customers/route.ts
@@ -1,13 +1,18 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { canAccessAdmin } from '@/lib/rbac';
+import { canAccessAdmin, canAccessViewer, isMachinist } from '@/lib/rbac';
 import { prisma } from '@/lib/prisma';
 
 export async function GET(req: NextRequest) {
   const session = await getServerSession(authOptions);
-  if (!session || !canAccessAdmin(session.user as any)) {
+  if (!session) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+  const user = session.user as any;
+  const canView = canAccessAdmin(user) || isMachinist(user) || canAccessViewer(user);
+  if (!canView) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
   }
   const { searchParams } = new URL(req.url);
   const take = parseInt(searchParams.get('take') || '100', 10);

--- a/src/app/api/admin/materials/route.ts
+++ b/src/app/api/admin/materials/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { canAccessAdmin } from '@/lib/rbac';
+import { canAccessAdmin, canAccessViewer, isMachinist } from '@/lib/rbac';
 
 const prisma = new PrismaClient();
 
@@ -14,10 +14,21 @@ async function requireAdmin(): Promise<NextResponse | null> {
   return null;
 }
 
+async function requireTeamAccess(): Promise<NextResponse | null> {
+  const session = await getServerSession(authOptions);
+  if (!session) return new NextResponse('Unauthorized', { status: 401 });
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role) && !isMachinist(role) && !canAccessViewer(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+  return null;
+}
+
 import { MaterialUpsert } from '@/lib/zod';
 
 export async function GET(req: NextRequest) {
-  const guard = await requireAdmin(); if (guard) return guard;
+  const guard = await requireTeamAccess();
+  if (guard) return guard;
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q') || undefined;
   const cursor = searchParams.get('cursor');

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { PrismaClient } from '@prisma/client';
 import { getServerSession } from 'next-auth';
 import { authOptions } from '@/lib/auth';
-import { canAccessAdmin } from '@/lib/rbac';
+import { canAccessAdmin, canAccessViewer, isMachinist } from '@/lib/rbac';
 
 const prisma = new PrismaClient();
 
@@ -14,18 +14,39 @@ async function requireAdmin(): Promise<NextResponse | null> {
   return null;
 }
 
+async function requireTeamAccess(): Promise<NextResponse | null> {
+  const session = await getServerSession(authOptions);
+  if (!session) return new NextResponse('Unauthorized', { status: 401 });
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role) && !isMachinist(role) && !canAccessViewer(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+  return null;
+}
+
 import { UserUpsert } from '@/lib/zod';
 
 export async function GET(req: NextRequest) {
-  const guard = await requireAdmin(); if (guard) return guard;
+  const guard = await requireTeamAccess();
+  if (guard) return guard;
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q') || undefined;
   const cursor = searchParams.get('cursor');
   const take = Number(searchParams.get('take') || '20');
+  const roleFilter = searchParams.get('role') || undefined;
 
-  const where = q ? { OR: [{ name: { contains: q, mode: 'insensitive' } }, { email: { contains: q, mode: 'insensitive' } }] } as any : undefined;
+  const where: any = {};
+  if (q) {
+    where.OR = [
+      { name: { contains: q, mode: 'insensitive' } },
+      { email: { contains: q, mode: 'insensitive' } },
+    ];
+  }
+  if (roleFilter) {
+    where.role = roleFilter;
+  }
   const items = await prisma.user.findMany({
-    where,
+    where: Object.keys(where).length > 0 ? where : undefined,
     orderBy: { id: 'asc' },
     take: take + 1,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),

--- a/src/app/api/whoami/route.ts
+++ b/src/app/api/whoami/route.ts
@@ -7,6 +7,9 @@ export async function GET(_req: NextRequest) {
   if (!session?.user?.email) {
     return new NextResponse('Unauthorized', { status: 401 });
   }
-  const role = (session.user as any).role as string | undefined;
-  return NextResponse.json({ email: session.user.email, role });
+  const user = session.user as any;
+  const role = user?.role as string | undefined;
+  const id = user?.id as string | undefined;
+  const name = user?.name as string | undefined;
+  return NextResponse.json({ email: session.user.email, role, id, name });
 }


### PR DESCRIPTION
## Summary
- allow authenticated machinists (and viewers) to read customers, vendors, materials, and user lists used for order creation and filtering
- expose the current user's id from the whoami endpoint and update the navigation to surface the machinist profile link while only showing the admin area to admins
- filter machinist profile timing metrics to only consider programming, running, and ready for addons status updates

## Testing
- CI=1 pnpm build *(fails: Prisma engine download blocked in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d433b16cf883278a66340c348563fd