### PR TITLE
Add admin quoting tools and add-on pricing management

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model User {
   passwordHash     String?
 
   orders           Order[]  @relation("AssignedOrders")
+  quotes           Quote[]
   notes            Note[]
   timeLogs         TimeLog[]
   checklistToggles OrderChecklist[] @relation("ChecklistToggledBy")
@@ -38,6 +39,7 @@ model Customer {
   address String?
 
   orders  Order[]
+  quotes  Quote[]
 
   @@index([name])
   @@unique([name])
@@ -60,6 +62,7 @@ model Vendor {
   notes  String?
 
   orders Order[]
+  quoteVendorItems QuoteVendorItem[]
 }
 
 model ChecklistItem {
@@ -158,5 +161,108 @@ model StatusHistory {
   userId    String?
   user      User?    @relation("UserStatusHistory", fields: [userId], references: [id])
   reason    String?
+  createdAt DateTime @default(now())
+}
+
+model Addon {
+  id          String   @id @default(cuid())
+  name        String
+  description String? @db.Text
+  rateType    String
+  rateCents   Int
+  active      Boolean  @default(true)
+
+  quoteSelections QuoteAddonSelection[]
+
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([active])
+  @@unique([name])
+}
+
+model Quote {
+  id               String   @id @default(cuid())
+  quoteNumber      String
+  companyName      String
+  contactName      String?
+  contactEmail     String?
+  contactPhone     String?
+  customerId       String?
+  customer         Customer? @relation(fields: [customerId], references: [id])
+  status           String    @default("DRAFT")
+  materialSummary  String?   @db.Text
+  purchaseItems    String?   @db.Text
+  requirements     String?   @db.Text
+  notes            String?   @db.Text
+  multiPiece       Boolean   @default(false)
+  basePriceCents   Int       @default(0)
+  addonsTotalCents Int       @default(0)
+  vendorTotalCents Int       @default(0)
+  totalCents       Int       @default(0)
+  metadata         Json?
+
+  createdById String
+  createdBy   User     @relation(fields: [createdById], references: [id])
+
+  parts           QuotePart[]
+  vendorItems     QuoteVendorItem[]
+  addonSelections QuoteAddonSelection[]
+  attachments     QuoteAttachment[]
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([status])
+  @@index([companyName])
+  @@unique([quoteNumber])
+}
+
+model QuotePart {
+  id         String @id @default(cuid())
+  quoteId    String
+  quote      Quote  @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+  name       String
+  description String? @db.Text
+  quantity   Int    @default(1)
+  pieceCount Int    @default(1)
+  notes      String? @db.Text
+}
+
+model QuoteVendorItem {
+  id              String  @id @default(cuid())
+  quoteId         String
+  quote           Quote   @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+  vendorId        String?
+  vendor          Vendor? @relation(fields: [vendorId], references: [id])
+  vendorName      String?
+  partNumber      String?
+  partUrl         String?
+  basePriceCents  Int     @default(0)
+  markupPercent   Float   @default(0)
+  finalPriceCents Int     @default(0)
+  notes           String? @db.Text
+}
+
+model QuoteAddonSelection {
+  id               String @id @default(cuid())
+  quoteId          String
+  quote            Quote  @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+  addonId          String
+  addon            Addon  @relation(fields: [addonId], references: [id])
+  units            Float  @default(0)
+  rateTypeSnapshot String
+  rateCents        Int
+  totalCents       Int
+  notes            String? @db.Text
+}
+
+model QuoteAttachment {
+  id        String   @id @default(cuid())
+  quoteId   String
+  quote     Quote    @relation(fields: [quoteId], references: [id], onDelete: Cascade)
+  url       String
+  label     String?
+  mimeType  String?
   createdAt DateTime @default(now())
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -17,13 +17,16 @@ async function main() {
   }
 
   // Vendors
-  for (const v of [
+  const vendorSeeds = [
     { name: 'McMaster-Carr' },
     { name: 'Grainger' },
     { name: 'OnlineMetals' },
     { name: 'Yamazen' },
-  ]) {
-    await prisma.vendor.upsert({ where: { name: v.name }, update: {}, create: v });
+  ];
+  const vendorRecords = [] as Awaited<ReturnType<typeof prisma.vendor.upsert>>[];
+  for (const v of vendorSeeds) {
+    const record = await prisma.vendor.upsert({ where: { name: v.name }, update: {}, create: v });
+    vendorRecords.push(record);
   }
 
   // Checklist items
@@ -35,6 +38,30 @@ async function main() {
     { label: 'QC plan attached' },
   ]) {
     await prisma.checklistItem.upsert({ where: { label: c.label }, update: {}, create: c });
+  }
+
+  const addonSeeds = [
+    { name: 'Saw', rateType: 'HOURLY', rateCents: 7500, description: 'Saw cutting time per hour.' },
+    { name: 'Weld', rateType: 'HOURLY', rateCents: 9000, description: 'Welding labor per hour.' },
+    { name: 'Program Time', rateType: 'HOURLY', rateCents: 8500, description: 'CAM and CNC programming time.' },
+    { name: 'Setup Time', rateType: 'HOURLY', rateCents: 7000, description: 'Machine setup labor per hour.' },
+    { name: 'Mill Time', rateType: 'HOURLY', rateCents: 8200, description: 'Mill runtime per hour.' },
+    { name: 'Lathe Time', rateType: 'HOURLY', rateCents: 7800, description: 'Lathe runtime per hour.' },
+    { name: 'Flat Rate Handling', rateType: 'FLAT', rateCents: 2500, description: 'Fixed charge for handling or packaging.' },
+  ];
+  const addonRecords = [] as Awaited<ReturnType<typeof prisma.addon.upsert>>[];
+  for (const addon of addonSeeds) {
+    const record = await prisma.addon.upsert({
+      where: { name: addon.name },
+      update: {
+        description: addon.description,
+        rateType: addon.rateType,
+        rateCents: addon.rateCents,
+        active: true,
+      },
+      create: addon,
+    });
+    addonRecords.push(record);
   }
 
   // Customers
@@ -129,6 +156,117 @@ async function main() {
   await seedOrder(6, acme.id, null);
   await seedOrder(7, wayne.id, mach1.id);
   await seedOrder(8, wayne.id, mach2.id);
+
+  const sawAddon = addonRecords.find((a) => a.name === 'Saw');
+  const weldAddon = addonRecords.find((a) => a.name === 'Weld');
+  const setupAddon = addonRecords.find((a) => a.name === 'Setup Time');
+  const millAddon = addonRecords.find((a) => a.name === 'Mill Time');
+  const mcmaster = vendorRecords.find((v) => v.name === 'McMaster-Carr');
+
+  if (sawAddon && weldAddon && setupAddon && millAddon && mcmaster) {
+    const sawTotal = Math.round(sawAddon.rateCents * 1.5);
+    const weldTotal = Math.round(weldAddon.rateCents * 2.0);
+    const setupTotal = Math.round(setupAddon.rateCents * 1.25);
+    const millTotal = Math.round(millAddon.rateCents * 2.5);
+    const addonsTotal = sawTotal + weldTotal + setupTotal + millTotal;
+    const basePrice = 245000;
+    const vendorPrice = Math.round(6800 * 1.2);
+    await prisma.quote.upsert({
+      where: { quoteNumber: 'Q-1001' },
+      update: {},
+      create: {
+        quoteNumber: 'Q-1001',
+        companyName: 'ACME Corp',
+        contactName: 'Jane Engineer',
+        contactEmail: 'jane.engineer@acme.example',
+        contactPhone: '555-0102',
+        customerId: acme.id,
+        status: 'DRAFT',
+        materialSummary: '6061-T6 plate and DOM tubing per print.',
+        purchaseItems: 'Hardware kit, anchors, powder coat service TBD.',
+        requirements: 'Tube welded to base, grind flush, powder coat black.',
+        basePriceCents: basePrice,
+        vendorTotalCents: vendorPrice,
+        addonsTotalCents: addonsTotal,
+        totalCents: basePrice + vendorPrice + addonsTotal,
+        multiPiece: true,
+        notes: 'Initial quote prepared from legacy spreadsheet.',
+        createdById: admin.id,
+        metadata: {
+          markupNotes: 'Vendor markup applied at 20%. Labor captured via addons.',
+        },
+        parts: {
+          create: [
+            {
+              name: 'Base and Tube Assembly',
+              description: 'Base plate with welded tube; machine critical faces after welding.',
+              quantity: 1,
+              pieceCount: 2,
+              notes: 'Includes weld prep and machining of finished assembly.',
+            },
+          ],
+        },
+        vendorItems: {
+          create: [
+            {
+              vendorId: mcmaster.id,
+              vendorName: mcmaster.name,
+              partNumber: '91251A289',
+              partUrl: 'https://www.mcmaster.com/91251A289/',
+              basePriceCents: 6800,
+              markupPercent: 20,
+              finalPriceCents: vendorPrice,
+              notes: 'Fastener kit per customer spec.',
+            },
+          ],
+        },
+        addonSelections: {
+          create: [
+            {
+              addonId: sawAddon.id,
+              units: 1.5,
+              rateTypeSnapshot: sawAddon.rateType,
+              rateCents: sawAddon.rateCents,
+              totalCents: sawTotal,
+              notes: 'Cut raw stock for base and tube.',
+            },
+            {
+              addonId: weldAddon.id,
+              units: 2.0,
+              rateTypeSnapshot: weldAddon.rateType,
+              rateCents: weldAddon.rateCents,
+              totalCents: weldTotal,
+              notes: 'Weld assembly with fixture.',
+            },
+            {
+              addonId: setupAddon.id,
+              units: 1.25,
+              rateTypeSnapshot: setupAddon.rateType,
+              rateCents: setupAddon.rateCents,
+              totalCents: setupTotal,
+              notes: 'Fixture and machine setup.',
+            },
+            {
+              addonId: millAddon.id,
+              units: 2.5,
+              rateTypeSnapshot: millAddon.rateType,
+              rateCents: millAddon.rateCents,
+              totalCents: millTotal,
+              notes: 'Finish mill passes on assembly.',
+            },
+          ],
+        },
+        attachments: {
+          create: [
+            {
+              url: 'https://example.com/quotes/Q-1001/customer-print.pdf',
+              label: 'Customer print',
+            },
+          ],
+        },
+      },
+    });
+  }
 }
 
 main().catch(e => {

--- a/src/app/admin/addons/client.tsx
+++ b/src/app/admin/addons/client.tsx
@@ -1,0 +1,267 @@
+'use client';
+
+import React, { useEffect, useMemo, useState } from 'react';
+
+import Table from '@/components/Admin/Table';
+import { useToast } from '@/components/ui/Toast';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/Textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { fetchJson } from '@/lib/fetchJson';
+import { AddonUpsert } from '@/lib/zod';
+
+interface Item {
+  id: string;
+  name: string;
+  description?: string | null;
+  rateType: 'HOURLY' | 'FLAT';
+  rateCents: number;
+  active: boolean;
+}
+
+interface ClientProps {
+  initial: { items: Item[]; nextCursor: string | null };
+}
+
+type DialogState = { mode: 'create' | 'edit'; data?: Item } | null;
+
+const formatCurrency = (cents: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((cents || 0) / 100);
+
+const RATE_LABEL: Record<Item['rateType'], string> = {
+  HOURLY: 'Hourly',
+  FLAT: 'Flat rate',
+};
+
+export default function Client({ initial }: ClientProps) {
+  const [items, setItems] = useState<Item[]>(initial.items ?? []);
+  const [nextCursor, setNextCursor] = useState<string | null>(initial.nextCursor ?? null);
+  const [query, setQuery] = useState('');
+  const [dialog, setDialog] = useState<DialogState>(null);
+  const [form, setForm] = useState({
+    name: '',
+    description: '',
+    rateType: 'HOURLY' as Item['rateType'],
+    rate: '0.00',
+    active: true,
+  });
+  const toast = useToast();
+
+  useEffect(() => {
+    if (dialog?.mode === 'edit' && dialog.data) {
+      setForm({
+        name: dialog.data.name,
+        description: dialog.data.description ?? '',
+        rateType: dialog.data.rateType,
+        rate: (dialog.data.rateCents / 100).toFixed(2),
+        active: dialog.data.active,
+      });
+    } else if (dialog?.mode === 'create') {
+      setForm({ name: '', description: '', rateType: 'HOURLY', rate: '0.00', active: true });
+    }
+  }, [dialog]);
+
+  const columns = useMemo(
+    () => [
+      { key: 'name', header: 'Name' },
+      {
+        key: 'rateType',
+        header: 'Billing',
+        render: (value: Item['rateType']) => RATE_LABEL[value] ?? value,
+      },
+      {
+        key: 'rateCents',
+        header: 'Rate',
+        render: (_: number, row: Item) =>
+          `${formatCurrency(row.rateCents)}${row.rateType === 'HOURLY' ? ' / hr' : ''}`,
+      },
+      {
+        key: 'active',
+        header: 'Active',
+        render: (value: boolean) => (value ? 'Yes' : 'No'),
+      },
+      {
+        key: 'description',
+        header: 'Description',
+      },
+    ],
+    []
+  );
+
+  async function refresh(cursor?: string) {
+    const qs = new URLSearchParams();
+    if (query) qs.set('q', query);
+    if (cursor) qs.set('cursor', cursor);
+    const data = await fetchJson<{ items: Item[]; nextCursor: string | null }>(
+      `/api/admin/addons?${qs.toString()}`
+    );
+    setItems(cursor ? [...items, ...(data.items ?? [])] : data.items ?? []);
+    setNextCursor(data.nextCursor ?? null);
+  }
+
+  async function save() {
+    let rateCents = 0;
+    try {
+      const parsedRate = Number.parseFloat(form.rate);
+      if (Number.isNaN(parsedRate) || parsedRate < 0) {
+        throw new Error('Enter a valid rate in dollars');
+      }
+      rateCents = Math.round(parsedRate * 100);
+    } catch (error: any) {
+      toast.push(error.message ?? 'Invalid rate', 'error');
+      return;
+    }
+
+    const payload = AddonUpsert.parse({
+      name: form.name,
+      description: form.description || undefined,
+      rateType: form.rateType,
+      rateCents,
+      active: form.active,
+    });
+
+    try {
+      if (dialog?.mode === 'edit' && dialog.data) {
+        const res = await fetchJson<{ item: Item }>(`/api/admin/addons/${dialog.data.id}`, {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        setItems(items.map((i) => (i.id === dialog.data?.id ? res.item : i)));
+        toast.push('Add-on updated', 'success');
+      } else {
+        const res = await fetchJson<{ item: Item }>(`/api/admin/addons`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        });
+        setItems([res.item, ...items]);
+        toast.push('Add-on created', 'success');
+      }
+      setDialog(null);
+    } catch (error: any) {
+      toast.push(error.message || 'Failed to save add-on', 'error');
+    }
+  }
+
+  async function remove(row: Item) {
+    await fetchJson(`/api/admin/addons/${row.id}`, { method: 'DELETE' });
+    setItems(items.filter((i) => i.id !== row.id));
+    toast.push('Add-on deleted', 'success');
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search add-ons"
+          className="w-full max-w-xs"
+        />
+        <Button variant="outline" onClick={() => refresh()}>
+          Search
+        </Button>
+        <div className="flex-1" />
+        <Button onClick={() => setDialog({ mode: 'create' })}>New add-on</Button>
+      </div>
+
+      <Table columns={columns as any} rows={items} onEdit={(row) => setDialog({ mode: 'edit', data: row })} onDelete={remove} />
+
+      {nextCursor && (
+        <div className="flex justify-center">
+          <Button variant="outline" onClick={() => refresh(nextCursor)}>
+            Load more
+          </Button>
+        </div>
+      )}
+
+      <Dialog open={dialog !== null} onOpenChange={(open) => !open && setDialog(null)}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{dialog?.mode === 'edit' ? 'Edit add-on' : 'New add-on'}</DialogTitle>
+            <DialogDescription>Hourly or fixed-rate services are available to admins while quoting.</DialogDescription>
+          </DialogHeader>
+          <form
+            className="space-y-4"
+            onSubmit={(event) => {
+              event.preventDefault();
+              void save();
+            }}
+          >
+            <div className="grid gap-2">
+              <Label htmlFor="addonName">Name</Label>
+              <Input
+                id="addonName"
+                value={form.name}
+                onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="addonRateType">Billing type</Label>
+              <select
+                id="addonRateType"
+                value={form.rateType}
+                onChange={(event) =>
+                  setForm((prev) => ({ ...prev, rateType: event.target.value as Item['rateType'] }))
+                }
+                className="rounded border border-border bg-background px-3 py-2 text-sm"
+              >
+                <option value="HOURLY">Hourly</option>
+                <option value="FLAT">Flat rate</option>
+              </select>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="addonRate">Rate (USD)</Label>
+              <Input
+                id="addonRate"
+                type="number"
+                step="0.01"
+                min="0"
+                value={form.rate}
+                onChange={(event) => setForm((prev) => ({ ...prev, rate: event.target.value }))}
+                required
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="addonDescription">Description</Label>
+              <Textarea
+                id="addonDescription"
+                value={form.description}
+                onChange={(event) => setForm((prev) => ({ ...prev, description: event.target.value }))}
+                placeholder="Optional details such as when to apply this add-on"
+              />
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="addonActive"
+                checked={form.active}
+                onCheckedChange={(checked) => setForm((prev) => ({ ...prev, active: Boolean(checked) }))}
+              />
+              <Label htmlFor="addonActive" className="text-sm font-normal">
+                Active and available on new quotes
+              </Label>
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="ghost" onClick={() => setDialog(null)}>
+                Cancel
+              </Button>
+              <Button type="submit">Save</Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/app/admin/addons/page.tsx
+++ b/src/app/admin/addons/page.tsx
@@ -1,0 +1,34 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import NavTabs from '@/components/Admin/NavTabs';
+import { ToastProvider } from '@/components/ui/Toast';
+import { prisma } from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import Client from './client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const session = await getServerSession(authOptions);
+  if (!session || !canAccessAdmin((session.user as any)?.role)) {
+    redirect('/');
+  }
+
+  const items = await prisma.addon.findMany({ orderBy: { name: 'asc' }, take: 50 });
+  const initial = { items, nextCursor: null };
+
+  return (
+    <div className="p-4 text-neutral-100">
+      <NavTabs />
+      <h1 className="text-xl font-semibold mb-3">Add-ons</h1>
+      <p className="text-sm text-muted-foreground mb-6">
+        Configure hourly or flat-rate services that can be attached to quotes and orders. Rates are only visible to admins.
+      </p>
+      <ToastProvider>
+        <Client initial={initial} />
+      </ToastProvider>
+    </div>
+  );
+}

--- a/src/app/admin/quotes/QuoteEditor.tsx
+++ b/src/app/admin/quotes/QuoteEditor.tsx
@@ -1,0 +1,999 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useEffect, useMemo, useState } from 'react';
+
+import { useToast } from '@/components/ui/Toast';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { Textarea } from '@/components/ui/Textarea';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/Card';
+import { fetchJson } from '@/lib/fetchJson';
+
+import type { QuoteCreateInput } from '@/lib/zod-quotes';
+
+type Option = { id: string; name: string };
+
+type AddonOption = {
+  id: string;
+  name: string;
+  rateType: 'HOURLY' | 'FLAT';
+  rateCents: number;
+  active: boolean;
+  description?: string | null;
+};
+
+type QuotePartState = {
+  key: string;
+  name: string;
+  description: string;
+  quantity: string;
+  pieceCount: string;
+  notes: string;
+};
+
+type QuoteVendorItemState = {
+  key: string;
+  vendorId: string;
+  vendorName: string;
+  partNumber: string;
+  partUrl: string;
+  basePrice: string;
+  markupPercent: string;
+  notes: string;
+};
+
+type QuoteAddonState = {
+  key: string;
+  addonId: string;
+  units: string;
+  notes: string;
+};
+
+type AttachmentState = {
+  key: string;
+  url: string;
+  label: string;
+  mimeType: string;
+};
+
+type QuoteDetail = {
+  id: string;
+  quoteNumber: string;
+  companyName: string;
+  contactName?: string | null;
+  contactEmail?: string | null;
+  contactPhone?: string | null;
+  customerId?: string | null;
+  status: string;
+  materialSummary?: string | null;
+  purchaseItems?: string | null;
+  requirements?: string | null;
+  notes?: string | null;
+  basePriceCents: number;
+  vendorTotalCents: number;
+  addonsTotalCents: number;
+  totalCents: number;
+  multiPiece: boolean;
+  parts: Array<{
+    id: string;
+    name: string;
+    description?: string | null;
+    quantity: number;
+    pieceCount: number;
+    notes?: string | null;
+  }>;
+  vendorItems: Array<{
+    id: string;
+    vendorId?: string | null;
+    vendorName?: string | null;
+    partNumber?: string | null;
+    partUrl?: string | null;
+    basePriceCents: number;
+    markupPercent: number;
+    finalPriceCents: number;
+    notes?: string | null;
+  }>;
+  addonSelections: Array<{
+    id: string;
+    addonId: string;
+    units: number;
+    rateTypeSnapshot: string;
+    rateCents: number;
+    totalCents: number;
+    notes?: string | null;
+    addon?: { id: string; name: string; rateType: string; rateCents: number } | null;
+  }>;
+  attachments: Array<{
+    id: string;
+    url: string;
+    label?: string | null;
+    mimeType?: string | null;
+  }>;
+};
+
+interface QuoteEditorProps {
+  mode: 'create' | 'edit';
+  initialQuote?: QuoteDetail;
+}
+
+const STATUS_OPTIONS = [
+  { value: 'DRAFT', label: 'Draft' },
+  { value: 'SENT', label: 'Sent' },
+  { value: 'APPROVED', label: 'Approved' },
+  { value: 'EXPIRED', label: 'Expired' },
+];
+
+const MARKUP_SUGGESTIONS = [10, 15, 20];
+
+const formatCurrency = (cents: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((cents || 0) / 100);
+
+const centsFromString = (value: string) => {
+  const parsed = Number.parseFloat(value || '0');
+  if (Number.isNaN(parsed) || parsed < 0) return 0;
+  return Math.round(parsed * 100);
+};
+
+const numberFromString = (value: string) => {
+  const parsed = Number.parseFloat(value || '0');
+  if (Number.isNaN(parsed)) return 0;
+  return parsed;
+};
+
+const createKey = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+
+export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
+  const router = useRouter();
+  const toast = useToast();
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [addons, setAddons] = useState<AddonOption[]>([]);
+  const [vendors, setVendors] = useState<Option[]>([]);
+  const [customers, setCustomers] = useState<Option[]>([]);
+
+  const [form, setForm] = useState({
+    quoteNumber: initialQuote?.quoteNumber ?? '',
+    companyName: initialQuote?.companyName ?? '',
+    contactName: initialQuote?.contactName ?? '',
+    contactEmail: initialQuote?.contactEmail ?? '',
+    contactPhone: initialQuote?.contactPhone ?? '',
+    customerId: initialQuote?.customerId ?? '',
+    status: initialQuote?.status ?? 'DRAFT',
+    materialSummary: initialQuote?.materialSummary ?? '',
+    purchaseItems: initialQuote?.purchaseItems ?? '',
+    requirements: initialQuote?.requirements ?? '',
+    notes: initialQuote?.notes ?? '',
+    basePrice: ((initialQuote?.basePriceCents ?? 0) / 100).toFixed(2),
+    multiPiece: initialQuote?.multiPiece ?? false,
+  });
+
+  const [parts, setParts] = useState<QuotePartState[]>(
+    (initialQuote?.parts ?? []).map((part) => ({
+      key: part.id,
+      name: part.name,
+      description: part.description ?? '',
+      quantity: String(part.quantity ?? 1),
+      pieceCount: String(part.pieceCount ?? 1),
+      notes: part.notes ?? '',
+    }))
+  );
+
+  const [vendorItems, setVendorItems] = useState<QuoteVendorItemState[]>(
+    (initialQuote?.vendorItems ?? []).map((item) => ({
+      key: item.id,
+      vendorId: item.vendorId ?? '',
+      vendorName: item.vendorName ?? '',
+      partNumber: item.partNumber ?? '',
+      partUrl: item.partUrl ?? '',
+      basePrice: ((item.basePriceCents ?? 0) / 100).toFixed(2),
+      markupPercent: String(item.markupPercent ?? 0),
+      notes: item.notes ?? '',
+    }))
+  );
+
+  const [addonSelections, setAddonSelections] = useState<QuoteAddonState[]>(
+    (initialQuote?.addonSelections ?? []).map((selection) => ({
+      key: selection.id,
+      addonId: selection.addonId,
+      units: String(selection.units ?? 0),
+      notes: selection.notes ?? '',
+    }))
+  );
+
+  const [attachments, setAttachments] = useState<AttachmentState[]>(
+    (initialQuote?.attachments ?? []).map((attachment) => ({
+      key: attachment.id,
+      url: attachment.url,
+      label: attachment.label ?? '',
+      mimeType: attachment.mimeType ?? '',
+    }))
+  );
+
+  useEffect(() => {
+    fetch('/api/admin/addons?active=true&take=100', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+      .then((data) => {
+        const list = Array.isArray(data?.items) ? data.items : data;
+        setAddons(
+          (list ?? []).map((item: any) => ({
+            id: item.id,
+            name: item.name,
+            rateType: item.rateType,
+            rateCents: item.rateCents,
+            active: item.active,
+            description: item.description,
+          }))
+        );
+      })
+      .catch(() => setAddons([]));
+
+    fetch('/api/admin/vendors?take=100', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+      .then((data) => {
+        const list = Array.isArray(data?.items) ? data.items : data;
+        setVendors((list ?? []).map((item: any) => ({ id: item.id, name: item.name })));
+      })
+      .catch(() => setVendors([]));
+
+    fetch('/api/admin/customers?take=100', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+      .then((data) => {
+        const list = Array.isArray(data?.items) ? data.items : data;
+        setCustomers((list ?? []).map((item: any) => ({ id: item.id, name: item.name })));
+      })
+      .catch(() => setCustomers([]));
+  }, []);
+
+  function addPart() {
+    setParts((prev) => [
+      ...prev,
+      { key: createKey(), name: '', description: '', quantity: '1', pieceCount: '1', notes: '' },
+    ]);
+  }
+
+  function addVendorItem() {
+    setVendorItems((prev) => [
+      ...prev,
+      {
+        key: createKey(),
+        vendorId: '',
+        vendorName: '',
+        partNumber: '',
+        partUrl: '',
+        basePrice: '0.00',
+        markupPercent: '20',
+        notes: '',
+      },
+    ]);
+  }
+
+  function addAddonSelection() {
+    setAddonSelections((prev) => [
+      ...prev,
+      { key: createKey(), addonId: '', units: '1.0', notes: '' },
+    ]);
+  }
+
+  function addAttachment() {
+    setAttachments((prev) => [
+      ...prev,
+      { key: createKey(), url: '', label: '', mimeType: '' },
+    ]);
+  }
+
+  const addonMap = useMemo(() => new Map(addons.map((addon) => [addon.id, addon])), [addons]);
+
+  const vendorTotalsCents = vendorItems.reduce((sum, item) => {
+    const base = centsFromString(item.basePrice);
+    const markup = Number.parseFloat(item.markupPercent || '0');
+    const final = Math.round(base * (1 + (Number.isNaN(markup) ? 0 : markup / 100)));
+    return sum + (final > 0 ? final : 0);
+  }, 0);
+
+  const addonsTotalsCents = addonSelections.reduce((sum, selection) => {
+    const addon = addonMap.get(selection.addonId);
+    if (!addon) return sum;
+    const units = numberFromString(selection.units);
+    return sum + Math.round(addon.rateCents * (units > 0 ? units : 0));
+  }, 0);
+
+  const basePriceCents = centsFromString(form.basePrice);
+  const totalCents = basePriceCents + vendorTotalsCents + addonsTotalsCents;
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError(null);
+
+    const payload: QuoteCreateInput = {
+      quoteNumber: form.quoteNumber || undefined,
+      companyName: form.companyName,
+      contactName: form.contactName || undefined,
+      contactEmail: form.contactEmail || undefined,
+      contactPhone: form.contactPhone || undefined,
+      customerId: form.customerId || undefined,
+      status: form.status || 'DRAFT',
+      materialSummary: form.materialSummary || undefined,
+      purchaseItems: form.purchaseItems || undefined,
+      requirements: form.requirements || undefined,
+      notes: form.notes || undefined,
+      basePriceCents,
+      multiPiece: form.multiPiece,
+      parts: parts
+        .filter((part) => part.name.trim())
+        .map((part) => ({
+          name: part.name,
+          description: part.description || undefined,
+          quantity: Number.parseInt(part.quantity || '1', 10) || 1,
+          pieceCount: Number.parseInt(part.pieceCount || '1', 10) || 1,
+          notes: part.notes || undefined,
+        })),
+      vendorItems: vendorItems
+        .filter((item) => item.vendorId || item.vendorName || centsFromString(item.basePrice) > 0)
+        .map((item) => ({
+          vendorId: item.vendorId || undefined,
+          vendorName: item.vendorName || undefined,
+          partNumber: item.partNumber || undefined,
+          partUrl: item.partUrl || undefined,
+          basePriceCents: centsFromString(item.basePrice),
+          markupPercent: Number.parseFloat(item.markupPercent || '0') || 0,
+          finalPriceCents: 0,
+          notes: item.notes || undefined,
+        })),
+      addonSelections: addonSelections
+        .filter((selection) => selection.addonId)
+        .map((selection) => ({
+          addonId: selection.addonId,
+          units: numberFromString(selection.units),
+          notes: selection.notes || undefined,
+        })),
+      attachments: attachments
+        .filter((attachment) => attachment.url.trim().length > 0)
+        .map((attachment) => ({
+          url: attachment.url,
+          label: attachment.label || undefined,
+          mimeType: attachment.mimeType || undefined,
+        })),
+    } as QuoteCreateInput;
+
+    try {
+      const response =
+        mode === 'edit' && initialQuote
+          ? await fetchJson<{ item: QuoteDetail }>(`/api/admin/quotes/${initialQuote.id}`, {
+              method: 'PATCH',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            })
+          : await fetchJson<{ item: QuoteDetail }>(`/api/admin/quotes`, {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify(payload),
+            });
+
+      toast.push(mode === 'edit' ? 'Quote updated' : 'Quote created', 'success');
+      router.push(`/admin/quotes/${response.item.id}`);
+    } catch (err: any) {
+      setError(err?.body?.error || err.message || 'Failed to save quote');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <form className="space-y-6" onSubmit={handleSubmit}>
+      {error && (
+        <div className="rounded border border-red-500/40 bg-red-500/10 p-3 text-sm text-red-200">
+          {error}
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle>General information</CardTitle>
+          <CardDescription>Who is requesting the work and how we can reach them.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-2">
+            <Label htmlFor="quoteCompany">Company *</Label>
+            <Input
+              id="quoteCompany"
+              value={form.companyName}
+              onChange={(event) => setForm((prev) => ({ ...prev, companyName: event.target.value }))}
+              required
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteNumber">Quote #</Label>
+            <Input
+              id="quoteNumber"
+              value={form.quoteNumber}
+              onChange={(event) => setForm((prev) => ({ ...prev, quoteNumber: event.target.value }))}
+              placeholder="Auto-generated if blank"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteContact">Contact / Engineer</Label>
+            <Input
+              id="quoteContact"
+              value={form.contactName}
+              onChange={(event) => setForm((prev) => ({ ...prev, contactName: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteEmail">Contact email</Label>
+            <Input
+              id="quoteEmail"
+              type="email"
+              value={form.contactEmail}
+              onChange={(event) => setForm((prev) => ({ ...prev, contactEmail: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quotePhone">Contact phone</Label>
+            <Input
+              id="quotePhone"
+              value={form.contactPhone}
+              onChange={(event) => setForm((prev) => ({ ...prev, contactPhone: event.target.value }))}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteCustomer">Customer record</Label>
+            <select
+              id="quoteCustomer"
+              value={form.customerId}
+              onChange={(event) => setForm((prev) => ({ ...prev, customerId: event.target.value }))}
+              className="rounded border border-border bg-background px-3 py-2 text-sm"
+            >
+              <option value="">Unassigned</option>
+              {customers.map((customer) => (
+                <option key={customer.id} value={customer.id}>
+                  {customer.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteStatus">Status</Label>
+            <select
+              id="quoteStatus"
+              value={form.status}
+              onChange={(event) => setForm((prev) => ({ ...prev, status: event.target.value }))}
+              className="rounded border border-border bg-background px-3 py-2 text-sm"
+            >
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteBasePrice">Base fabrication price (USD)</Label>
+            <Input
+              id="quoteBasePrice"
+              type="number"
+              step="0.01"
+              min="0"
+              value={form.basePrice}
+              onChange={(event) => setForm((prev) => ({ ...prev, basePrice: event.target.value }))}
+            />
+          </div>
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="quoteMultiPiece"
+              checked={form.multiPiece}
+              onCheckedChange={(checked) => setForm((prev) => ({ ...prev, multiPiece: Boolean(checked) }))}
+            />
+            <Label htmlFor="quoteMultiPiece" className="text-sm font-normal">
+              Multi-piece assemblies included
+            </Label>
+          </div>
+        </CardContent>
+        <CardContent className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="quoteMaterials">Materials / stock summary</Label>
+            <Textarea
+              id="quoteMaterials"
+              value={form.materialSummary}
+              onChange={(event) => setForm((prev) => ({ ...prev, materialSummary: event.target.value }))}
+              placeholder="Material specs, thickness, and finish requirements"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quotePurchaseItems">Purchased items (hardware, kits, etc.)</Label>
+            <Textarea
+              id="quotePurchaseItems"
+              value={form.purchaseItems}
+              onChange={(event) => setForm((prev) => ({ ...prev, purchaseItems: event.target.value }))}
+              placeholder="List of hardware or kits that need to be procured"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteRequirements">Requirements / process notes</Label>
+            <Textarea
+              id="quoteRequirements"
+              value={form.requirements}
+              onChange={(event) => setForm((prev) => ({ ...prev, requirements: event.target.value }))}
+              placeholder="Welding, finishing, or inspection instructions"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="quoteNotes">Internal notes</Label>
+            <Textarea
+              id="quoteNotes"
+              value={form.notes}
+              onChange={(event) => setForm((prev) => ({ ...prev, notes: event.target.value }))}
+              placeholder="Internal notes for the estimating team"
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Parts</CardTitle>
+          <CardDescription>Break down the parts or assemblies included in this quote.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {parts.map((part, index) => (
+            <div key={part.key} className="rounded border border-border/50 bg-card/40 p-4">
+              <div className="flex items-start justify-between gap-4">
+                <div className="grid flex-1 gap-4 md:grid-cols-2">
+                  <div className="grid gap-2">
+                    <Label>Part name *</Label>
+                    <Input
+                      value={part.name}
+                      onChange={(event) =>
+                        setParts((prev) =>
+                          prev.map((item) => (item.key === part.key ? { ...item, name: event.target.value } : item))
+                        )
+                      }
+                      required
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Quantity</Label>
+                    <Input
+                      type="number"
+                      min="1"
+                      value={part.quantity}
+                      onChange={(event) =>
+                        setParts((prev) =>
+                          prev.map((item) => (item.key === part.key ? { ...item, quantity: event.target.value } : item))
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Piece count</Label>
+                    <Input
+                      type="number"
+                      min="1"
+                      value={part.pieceCount}
+                      onChange={(event) =>
+                        setParts((prev) =>
+                          prev.map((item) => (item.key === part.key ? { ...item, pieceCount: event.target.value } : item))
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Notes</Label>
+                    <Textarea
+                      value={part.notes}
+                      onChange={(event) =>
+                        setParts((prev) =>
+                          prev.map((item) => (item.key === part.key ? { ...item, notes: event.target.value } : item))
+                        )
+                      }
+                      placeholder="Optional internal notes"
+                    />
+                  </div>
+                </div>
+                <div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setParts((prev) => prev.filter((item) => item.key !== part.key))}
+                    disabled={parts.length === 1}
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+              <div className="grid gap-2 mt-4">
+                <Label>Description</Label>
+                <Textarea
+                  value={part.description}
+                  onChange={(event) =>
+                    setParts((prev) =>
+                      prev.map((item) => (item.key === part.key ? { ...item, description: event.target.value } : item))
+                    )
+                  }
+                  placeholder="What needs to happen for this part or assembly?"
+                />
+              </div>
+            </div>
+          ))}
+          <Button type="button" variant="outline" onClick={addPart}>
+            Add part
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Purchased items</CardTitle>
+          <CardDescription>
+            Track vendor-sourced hardware or kits. Suggest markup percentages below to keep estimates consistent.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {vendorItems.map((item) => {
+            const markupValue = Number.parseFloat(item.markupPercent || '0') || 0;
+            const finalCents = Math.round(centsFromString(item.basePrice) * (1 + markupValue / 100));
+            return (
+              <div key={item.key} className="rounded border border-border/50 bg-card/40 p-4">
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div className="grid gap-2">
+                    <Label>Vendor</Label>
+                    <select
+                      value={item.vendorId}
+                      onChange={(event) =>
+                        {
+                          const selected = vendors.find((option) => option.id === event.target.value);
+                          setVendorItems((prev) =>
+                            prev.map((row) =>
+                              row.key === item.key
+                                ? { ...row, vendorId: event.target.value, vendorName: selected?.name ?? '' }
+                                : row
+                            )
+                          );
+                        }
+                      }
+                      className="rounded border border-border bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="">Select vendor</option>
+                      {vendors.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Override vendor name</Label>
+                    <Input
+                      value={item.vendorName}
+                      onChange={(event) =>
+                        setVendorItems((prev) =>
+                          prev.map((row) =>
+                            row.key === item.key ? { ...row, vendorName: event.target.value } : row
+                          )
+                        )
+                      }
+                      placeholder={vendors.find((option) => option.id === item.vendorId)?.name}
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Part number</Label>
+                    <Input
+                      value={item.partNumber}
+                      onChange={(event) =>
+                        setVendorItems((prev) =>
+                          prev.map((row) => (row.key === item.key ? { ...row, partNumber: event.target.value } : row))
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Link</Label>
+                    <Input
+                      value={item.partUrl}
+                      onChange={(event) =>
+                        setVendorItems((prev) =>
+                          prev.map((row) => (row.key === item.key ? { ...row, partUrl: event.target.value } : row))
+                        )
+                      }
+                      placeholder="https://"
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Base cost (USD)</Label>
+                    <Input
+                      type="number"
+                      step="0.01"
+                      min="0"
+                      value={item.basePrice}
+                      onChange={(event) =>
+                        setVendorItems((prev) =>
+                          prev.map((row) => (row.key === item.key ? { ...row, basePrice: event.target.value } : row))
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Markup %</Label>
+                    <div className="flex items-center gap-2">
+                      <Input
+                        type="number"
+                        step="1"
+                        value={item.markupPercent}
+                        onChange={(event) =>
+                          setVendorItems((prev) =>
+                            prev.map((row) => (row.key === item.key ? { ...row, markupPercent: event.target.value } : row))
+                          )
+                        }
+                        className="w-24"
+                      />
+                      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+                        Suggestions:
+                        {MARKUP_SUGGESTIONS.map((suggestion) => (
+                          <button
+                            key={suggestion}
+                            type="button"
+                            className="rounded border border-border/60 bg-background px-2 py-1 text-xs"
+                            onClick={() =>
+                              setVendorItems((prev) =>
+                                prev.map((row) =>
+                                  row.key === item.key
+                                    ? { ...row, markupPercent: suggestion.toString() }
+                                    : row
+                                )
+                              )
+                            }
+                          >
+                            {suggestion}%
+                          </button>
+                        ))}
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div className="mt-4 flex items-center justify-between">
+                  <div className="text-sm text-muted-foreground">
+                    Estimated total: <span className="font-medium text-primary">{formatCurrency(finalCents)}</span>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() => setVendorItems((prev) => prev.filter((row) => row.key !== item.key))}
+                  >
+                    Remove
+                  </Button>
+                </div>
+                <div className="grid gap-2 mt-4">
+                  <Label>Notes</Label>
+                  <Textarea
+                    value={item.notes}
+                    onChange={(event) =>
+                      setVendorItems((prev) =>
+                        prev.map((row) => (row.key === item.key ? { ...row, notes: event.target.value } : row))
+                      )
+                    }
+                    placeholder="Why is this item required?"
+                  />
+                </div>
+              </div>
+            );
+          })}
+          <Button type="button" variant="outline" onClick={addVendorItem}>
+            Add purchased item
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add-ons and labor</CardTitle>
+          <CardDescription>Select add-ons to capture labor or fixed-rate services.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {addonSelections.map((selection) => {
+            const addon = addonMap.get(selection.addonId);
+            const units = numberFromString(selection.units);
+            const totalCents = addon ? Math.round(addon.rateCents * (units > 0 ? units : 0)) : 0;
+            return (
+              <div key={selection.key} className="rounded border border-border/50 bg-card/40 p-4">
+                <div className="grid gap-4 md:grid-cols-3">
+                  <div className="grid gap-2">
+                    <Label>Add-on</Label>
+                    <select
+                      value={selection.addonId}
+                      onChange={(event) =>
+                        setAddonSelections((prev) =>
+                          prev.map((row) => (row.key === selection.key ? { ...row, addonId: event.target.value } : row))
+                        )
+                      }
+                      className="rounded border border-border bg-background px-3 py-2 text-sm"
+                    >
+                      <option value="">Select add-on</option>
+                      {addons.map((option) => (
+                        <option key={option.id} value={option.id}>
+                          {option.name} ({option.rateType === 'HOURLY' ? 'Hourly' : 'Flat'})
+                        </option>
+                      ))}
+                    </select>
+                    {addon?.description && (
+                      <p className="text-xs text-muted-foreground mt-1">{addon.description}</p>
+                    )}
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>{addon?.rateType === 'FLAT' ? 'Quantity' : 'Hours'}</Label>
+                    <Input
+                      type="number"
+                      min="0"
+                      step="0.25"
+                      value={selection.units}
+                      onChange={(event) =>
+                        setAddonSelections((prev) =>
+                          prev.map((row) => (row.key === selection.key ? { ...row, units: event.target.value } : row))
+                        )
+                      }
+                    />
+                  </div>
+                  <div className="grid gap-2">
+                    <Label>Subtotal</Label>
+                    <div className="rounded border border-border/60 bg-background px-3 py-2 text-sm">
+                      {addon ? `${formatCurrency(addon.rateCents)} x ${units.toFixed(2)} = ${formatCurrency(totalCents)}` : '—'}
+                    </div>
+                  </div>
+                </div>
+                <div className="grid gap-2 mt-4">
+                  <Label>Notes</Label>
+                  <Textarea
+                    value={selection.notes}
+                    onChange={(event) =>
+                      setAddonSelections((prev) =>
+                        prev.map((row) => (row.key === selection.key ? { ...row, notes: event.target.value } : row))
+                      )
+                    }
+                  />
+                </div>
+                <div className="mt-4 flex justify-end">
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    onClick={() =>
+                      setAddonSelections((prev) => prev.filter((row) => row.key !== selection.key))
+                    }
+                  >
+                    Remove
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+          <Button type="button" variant="outline" onClick={addAddonSelection}>
+            Add labor/add-on
+          </Button>
+          {addons.length === 0 && (
+            <p className="text-xs text-muted-foreground">
+              Need more options? Configure add-ons in the{' '}
+              <Link href="/admin/addons" className="underline">
+                Add-ons admin panel
+              </Link>
+              .
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Attachments</CardTitle>
+          <CardDescription>Link drawings, spreadsheets, or other supporting documents.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {attachments.map((attachment) => (
+            <div key={attachment.key} className="grid gap-4 md:grid-cols-3 rounded border border-border/50 bg-card/40 p-4">
+              <div className="grid gap-2">
+                <Label>Label</Label>
+                <Input
+                  value={attachment.label}
+                  onChange={(event) =>
+                    setAttachments((prev) =>
+                      prev.map((row) => (row.key === attachment.key ? { ...row, label: event.target.value } : row))
+                    )
+                  }
+                  placeholder="Customer print"
+                />
+              </div>
+              <div className="grid gap-2 md:col-span-2">
+                <Label>URL</Label>
+                <Input
+                  value={attachment.url}
+                  onChange={(event) =>
+                    setAttachments((prev) =>
+                      prev.map((row) => (row.key === attachment.key ? { ...row, url: event.target.value } : row))
+                    )
+                  }
+                  placeholder="https://"
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label>MIME type</Label>
+                <Input
+                  value={attachment.mimeType}
+                  onChange={(event) =>
+                    setAttachments((prev) =>
+                      prev.map((row) => (row.key === attachment.key ? { ...row, mimeType: event.target.value } : row))
+                    )
+                  }
+                  placeholder="application/pdf"
+                />
+              </div>
+              <div className="flex items-end justify-end">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  onClick={() => setAttachments((prev) => prev.filter((row) => row.key !== attachment.key))}
+                >
+                  Remove
+                </Button>
+              </div>
+            </div>
+          ))}
+          <Button type="button" variant="outline" onClick={addAttachment}>
+            Add attachment
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Summary</CardTitle>
+          <CardDescription>Totals update automatically as you edit the quote.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-3">
+          <div className="flex items-center justify-between text-sm">
+            <span>Base fabrication</span>
+            <span className="font-medium">{formatCurrency(basePriceCents)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span>Vendor purchases</span>
+            <span className="font-medium">{formatCurrency(vendorTotalsCents)}</span>
+          </div>
+          <div className="flex items-center justify-between text-sm">
+            <span>Add-ons and labor</span>
+            <span className="font-medium">{formatCurrency(addonsTotalsCents)}</span>
+          </div>
+          <div className="border-t border-border/60 pt-3 text-sm font-semibold">
+            <div className="flex items-center justify-between">
+              <span>Total estimate</span>
+              <span className="text-lg text-primary">{formatCurrency(totalCents)}</span>
+            </div>
+          </div>
+        </CardContent>
+        <CardFooter className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Add-on rates remain private—only admins can view hourly costs.
+          </p>
+          <div className="flex gap-3">
+            <Button type="button" variant="outline" onClick={() => router.back()} disabled={loading}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={loading}>
+              {loading ? 'Saving…' : mode === 'edit' ? 'Save changes' : 'Create quote'}
+            </Button>
+          </div>
+        </CardFooter>
+      </Card>
+    </form>
+  );
+}

--- a/src/app/admin/quotes/[id]/edit/page.tsx
+++ b/src/app/admin/quotes/[id]/edit/page.tsx
@@ -1,0 +1,49 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import { ToastProvider } from '@/components/ui/Toast';
+import { prisma } from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import QuoteEditor from '../../QuoteEditor';
+
+export const dynamic = 'force-dynamic';
+
+export default async function EditQuotePage({ params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session || !canAccessAdmin((session.user as any)?.role)) {
+    redirect('/');
+  }
+
+  const quote = await prisma.quote.findUnique({
+    where: { id: params.id },
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      parts: true,
+      vendorItems: true,
+      addonSelections: {
+        include: { addon: { select: { id: true, name: true, rateType: true, rateCents: true } } },
+      },
+      attachments: true,
+    },
+  });
+
+  if (!quote) {
+    redirect('/admin/quotes');
+  }
+
+  return (
+    <div className="p-4 text-neutral-100 space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Edit quote {quote.quoteNumber}</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Update pricing, purchased items, or labor before sharing with the customer.
+        </p>
+      </div>
+      <ToastProvider>
+        <QuoteEditor mode="edit" initialQuote={quote as any} />
+      </ToastProvider>
+    </div>
+  );
+}

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -1,0 +1,292 @@
+import { notFound, redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+import Link from 'next/link';
+
+import { Button } from '@/components/ui/Button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/Card';
+import { prisma } from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: 'Draft',
+  SENT: 'Sent',
+  APPROVED: 'Approved',
+  EXPIRED: 'Expired',
+};
+
+const formatCurrency = (cents: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((cents || 0) / 100);
+
+export const dynamic = 'force-dynamic';
+
+export default async function QuoteDetailPage({ params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session || !canAccessAdmin((session.user as any)?.role)) {
+    redirect('/');
+  }
+
+  const quote = await prisma.quote.findUnique({
+    where: { id: params.id },
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      parts: true,
+      vendorItems: true,
+      addonSelections: {
+        include: { addon: { select: { id: true, name: true, rateType: true, rateCents: true } } },
+      },
+      attachments: true,
+    },
+  });
+
+  if (!quote) {
+    notFound();
+  }
+
+  const statusLabel = STATUS_LABELS[quote.status] ?? quote.status;
+  const addonTotal = quote.addonSelections.reduce((sum, selection) => sum + selection.totalCents, 0);
+  const vendorTotal = quote.vendorItems.reduce((sum, item) => sum + item.finalPriceCents, 0);
+
+  return (
+    <div className="p-4 text-neutral-100 space-y-6">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold">Quote {quote.quoteNumber}</h1>
+          <p className="text-sm text-muted-foreground">
+            Prepared for {quote.companyName}
+            {quote.contactName ? ` — attention: ${quote.contactName}` : ''}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1">
+            Created by {quote.createdBy?.name || quote.createdBy?.email || 'Unknown'} and last updated on{' '}
+            {new Date(quote.updatedAt).toLocaleString()}.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-3">
+          <Button asChild variant="outline">
+            <Link href={`/admin/quotes/${quote.id}/edit`}>Edit quote</Link>
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/admin/quotes/${quote.id}/print`} target="_blank" rel="noopener noreferrer">
+              Print
+            </Link>
+          </Button>
+          <Button variant="ghost" disabled title="Conversion to orders coming soon">
+            Convert to order
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <CardTitle>Overview</CardTitle>
+            <CardDescription>Primary contact and status.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Status</span>
+              <span className="font-medium">{statusLabel}</span>
+            </div>
+            {quote.customer?.name && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Customer</span>
+                <span className="font-medium">{quote.customer.name}</span>
+              </div>
+            )}
+            {quote.contactEmail && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Email</span>
+                <span className="font-medium">{quote.contactEmail}</span>
+              </div>
+            )}
+            {quote.contactPhone && (
+              <div className="flex justify-between">
+                <span className="text-muted-foreground">Phone</span>
+                <span className="font-medium">{quote.contactPhone}</span>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Totals</CardTitle>
+            <CardDescription>Only administrators can see internal pricing.</CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-2 text-sm">
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Base fabrication</span>
+              <span className="font-medium">{formatCurrency(quote.basePriceCents)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Vendor purchases</span>
+              <span className="font-medium">{formatCurrency(vendorTotal)}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Add-ons and labor</span>
+              <span className="font-medium">{formatCurrency(addonTotal)}</span>
+            </div>
+            <div className="border-t border-border/60 pt-2 flex justify-between text-base font-semibold">
+              <span>Total estimate</span>
+              <span className="text-primary">{formatCurrency(quote.totalCents)}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Materials & notes</CardTitle>
+          <CardDescription>Context captured during quoting.</CardDescription>
+        </CardHeader>
+        <CardContent className="grid gap-4 text-sm">
+          {quote.materialSummary && (
+            <div>
+              <h3 className="font-medium mb-1">Materials</h3>
+              <p className="whitespace-pre-wrap text-muted-foreground">{quote.materialSummary}</p>
+            </div>
+          )}
+          {quote.purchaseItems && (
+            <div>
+              <h3 className="font-medium mb-1">Purchase items</h3>
+              <p className="whitespace-pre-wrap text-muted-foreground">{quote.purchaseItems}</p>
+            </div>
+          )}
+          {quote.requirements && (
+            <div>
+              <h3 className="font-medium mb-1">Requirements</h3>
+              <p className="whitespace-pre-wrap text-muted-foreground">{quote.requirements}</p>
+            </div>
+          )}
+          {quote.notes && (
+            <div>
+              <h3 className="font-medium mb-1">Internal notes</h3>
+              <p className="whitespace-pre-wrap text-muted-foreground">{quote.notes}</p>
+            </div>
+          )}
+          {!quote.materialSummary && !quote.purchaseItems && !quote.requirements && !quote.notes && (
+            <p className="text-muted-foreground">No additional notes recorded.</p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Parts</CardTitle>
+          <CardDescription>Assemblies and components captured on the quote.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {quote.parts.length === 0 && <p className="text-sm text-muted-foreground">No parts recorded.</p>}
+          {quote.parts.map((part) => (
+            <div key={part.id} className="rounded border border-border/50 bg-card/40 p-4 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <h3 className="text-base font-medium">{part.name}</h3>
+                <span className="text-muted-foreground">
+                  Qty {part.quantity} • Pieces {part.pieceCount}
+                </span>
+              </div>
+              {part.description && (
+                <p className="mt-2 whitespace-pre-wrap text-muted-foreground">{part.description}</p>
+              )}
+              {part.notes && (
+                <p className="mt-2 text-xs text-muted-foreground">Notes: {part.notes}</p>
+              )}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Purchased items</CardTitle>
+          <CardDescription>Vendor-sourced components and their markups.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {quote.vendorItems.length === 0 && <p className="text-sm text-muted-foreground">No purchased items.</p>}
+          {quote.vendorItems.map((item) => (
+            <div key={item.id} className="rounded border border-border/50 bg-card/40 p-4 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-medium">{item.vendorName || 'Vendor not specified'}</p>
+                  {item.partNumber && <p className="text-xs text-muted-foreground">Part #: {item.partNumber}</p>}
+                  {item.partUrl && (
+                    <Link
+                      href={item.partUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-xs text-primary underline"
+                    >
+                      View link
+                    </Link>
+                  )}
+                </div>
+                <div className="text-right">
+                  <p>{formatCurrency(item.finalPriceCents)}</p>
+                  <p className="text-xs text-muted-foreground">
+                    Base {formatCurrency(item.basePriceCents)} • Markup {item.markupPercent}%
+                  </p>
+                </div>
+              </div>
+              {item.notes && <p className="mt-2 text-xs text-muted-foreground">{item.notes}</p>}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add-ons & labor</CardTitle>
+          <CardDescription>Hourly or fixed-rate services applied to the quote.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {quote.addonSelections.length === 0 && <p className="text-sm text-muted-foreground">No add-ons applied.</p>}
+          {quote.addonSelections.map((selection) => (
+            <div key={selection.id} className="rounded border border-border/50 bg-card/40 p-4 text-sm">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div>
+                  <p className="font-medium">{selection.addon?.name ?? 'Add-on removed'}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {selection.units} {selection.rateTypeSnapshot === 'FLAT' ? 'qty' : 'hrs'} • Rate{' '}
+                    {formatCurrency(selection.rateCents)}
+                  </p>
+                </div>
+                <div className="text-right font-medium">{formatCurrency(selection.totalCents)}</div>
+              </div>
+              {selection.notes && <p className="mt-2 text-xs text-muted-foreground">{selection.notes}</p>}
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Attachments</CardTitle>
+          <CardDescription>Drawings and supporting documents.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          {quote.attachments.length === 0 && <p className="text-muted-foreground">No attachments linked.</p>}
+          {quote.attachments.map((attachment) => (
+            <div key={attachment.id} className="flex items-center justify-between gap-4 rounded border border-border/40 bg-card/30 p-3">
+              <div>
+                <p className="font-medium">{attachment.label || attachment.url}</p>
+                {attachment.mimeType && <p className="text-xs text-muted-foreground">{attachment.mimeType}</p>}
+              </div>
+              <Button asChild variant="outline" size="sm">
+                <Link href={attachment.url} target="_blank" rel="noopener noreferrer">
+                  View
+                </Link>
+              </Button>
+            </div>
+          ))}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/src/app/admin/quotes/[id]/print/page.tsx
+++ b/src/app/admin/quotes/[id]/print/page.tsx
@@ -1,0 +1,182 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import { prisma } from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+
+const formatCurrency = (cents: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((cents || 0) / 100);
+
+export const dynamic = 'force-dynamic';
+
+export default async function QuotePrintPage({ params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session || !canAccessAdmin((session.user as any)?.role)) {
+    redirect('/');
+  }
+
+  const quote = await prisma.quote.findUnique({
+    where: { id: params.id },
+    include: {
+      customer: { select: { id: true, name: true } },
+      parts: true,
+      vendorItems: true,
+      addonSelections: { include: { addon: { select: { id: true, name: true, rateType: true, rateCents: true } } } },
+    },
+  });
+
+  if (!quote) {
+    redirect('/admin/quotes');
+  }
+
+  const addonTotal = quote.addonSelections.reduce((sum, selection) => sum + selection.totalCents, 0);
+  const vendorTotal = quote.vendorItems.reduce((sum, item) => sum + item.finalPriceCents, 0);
+  const total = quote.basePriceCents + addonTotal + vendorTotal;
+
+  return (
+    <div className="min-h-screen bg-white p-8 text-black">
+      <header className="flex items-start justify-between border-b border-black pb-4">
+        <div>
+          <h1 className="text-2xl font-bold tracking-wide">Quote #{quote.quoteNumber}</h1>
+          <p className="mt-1 text-sm">
+            {quote.companyName}
+            {quote.contactName ? ` — Attn: ${quote.contactName}` : ''}
+          </p>
+          {quote.contactEmail && <p className="text-xs">Email: {quote.contactEmail}</p>}
+          {quote.contactPhone && <p className="text-xs">Phone: {quote.contactPhone}</p>}
+          {quote.customer?.name && <p className="text-xs">Customer record: {quote.customer.name}</p>}
+        </div>
+        <div className="text-right text-sm">
+          <p>Date: {new Date(quote.updatedAt).toLocaleDateString()}</p>
+          <p className="font-semibold">Total: {formatCurrency(total)}</p>
+        </div>
+      </header>
+
+      <section className="mt-6">
+        <h2 className="border-b border-black pb-1 text-lg font-semibold uppercase tracking-wide">Scope of work</h2>
+        <table className="mt-3 w-full table-fixed border-collapse border border-black text-sm">
+          <thead className="bg-zinc-200">
+            <tr>
+              <th className="border border-black px-2 py-1 text-left">Part / Assembly</th>
+              <th className="border border-black px-2 py-1 text-left">Qty</th>
+              <th className="border border-black px-2 py-1 text-left">Pieces</th>
+              <th className="border border-black px-2 py-1 text-left">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {quote.parts.length === 0 && (
+              <tr>
+                <td className="border border-black px-2 py-2 text-center text-neutral-500">No parts recorded</td>
+                <td className="border border-black px-2 py-2" />
+                <td className="border border-black px-2 py-2" />
+                <td className="border border-black px-2 py-2" />
+              </tr>
+            )}
+            {quote.parts.map((part) => (
+              <tr key={part.id} className="align-top">
+                <td className="border border-black px-2 py-2">
+                  <div className="font-medium">{part.name}</div>
+                  {part.description && <div className="mt-1 whitespace-pre-wrap text-xs">{part.description}</div>}
+                </td>
+                <td className="border border-black px-2 py-2">{part.quantity}</td>
+                <td className="border border-black px-2 py-2">{part.pieceCount}</td>
+                <td className="border border-black px-2 py-2 whitespace-pre-wrap text-xs">{part.notes || ''}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="border-b border-black pb-1 text-lg font-semibold uppercase tracking-wide">Purchased items</h2>
+        <table className="mt-3 w-full table-fixed border-collapse border border-black text-sm">
+          <thead className="bg-zinc-200">
+            <tr>
+              <th className="border border-black px-2 py-1 text-left">Vendor</th>
+              <th className="border border-black px-2 py-1 text-left">Part #</th>
+              <th className="border border-black px-2 py-1 text-left">URL</th>
+              <th className="border border-black px-2 py-1 text-left">Price</th>
+            </tr>
+          </thead>
+          <tbody>
+            {quote.vendorItems.length === 0 && (
+              <tr>
+                <td className="border border-black px-2 py-2 text-center text-neutral-500" colSpan={4}>
+                  No purchased items
+                </td>
+              </tr>
+            )}
+            {quote.vendorItems.map((item) => (
+              <tr key={item.id} className="align-top">
+                <td className="border border-black px-2 py-2">
+                  <div className="font-medium">{item.vendorName || 'Vendor not specified'}</div>
+                  {item.notes && <div className="mt-1 text-xs">{item.notes}</div>}
+                </td>
+                <td className="border border-black px-2 py-2">{item.partNumber || '—'}</td>
+                <td className="border border-black px-2 py-2 break-words text-xs">{item.partUrl || '—'}</td>
+                <td className="border border-black px-2 py-2">{formatCurrency(item.finalPriceCents)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="border-b border-black pb-1 text-lg font-semibold uppercase tracking-wide">Labor / add-ons</h2>
+        <table className="mt-3 w-full table-fixed border-collapse border border-black text-sm">
+          <thead className="bg-zinc-200">
+            <tr>
+              <th className="border border-black px-2 py-1 text-left">Add-on</th>
+              <th className="border border-black px-2 py-1 text-left">Units</th>
+              <th className="border border-black px-2 py-1 text-left">Rate</th>
+              <th className="border border-black px-2 py-1 text-left">Subtotal</th>
+            </tr>
+          </thead>
+          <tbody>
+            {quote.addonSelections.length === 0 && (
+              <tr>
+                <td className="border border-black px-2 py-2 text-center text-neutral-500" colSpan={4}>
+                  No add-ons captured
+                </td>
+              </tr>
+            )}
+            {quote.addonSelections.map((selection) => (
+              <tr key={selection.id} className="align-top">
+                <td className="border border-black px-2 py-2">
+                  <div className="font-medium">{selection.addon?.name ?? 'Add-on removed'}</div>
+                  {selection.notes && <div className="mt-1 text-xs">{selection.notes}</div>}
+                </td>
+                <td className="border border-black px-2 py-2">{selection.units}</td>
+                <td className="border border-black px-2 py-2">{formatCurrency(selection.rateCents)}</td>
+                <td className="border border-black px-2 py-2">{formatCurrency(selection.totalCents)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+
+      <section className="mt-6">
+        <h2 className="border-b border-black pb-1 text-lg font-semibold uppercase tracking-wide">Totals</h2>
+        <div className="mt-3 grid max-w-md gap-2 text-sm">
+          <div className="flex justify-between">
+            <span>Base fabrication</span>
+            <span>{formatCurrency(quote.basePriceCents)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Vendor purchases</span>
+            <span>{formatCurrency(vendorTotal)}</span>
+          </div>
+          <div className="flex justify-between">
+            <span>Add-ons & labor</span>
+            <span>{formatCurrency(addonTotal)}</span>
+          </div>
+          <div className="mt-1 flex justify-between border-t border-black pt-2 text-base font-semibold">
+            <span>Total</span>
+            <span>{formatCurrency(total)}</span>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/src/app/admin/quotes/client.tsx
+++ b/src/app/admin/quotes/client.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import React, { useMemo, useState } from 'react';
+
+import Table from '@/components/Admin/Table';
+import { useToast } from '@/components/ui/Toast';
+import { Button } from '@/components/ui/Button';
+import { Input } from '@/components/ui/Input';
+import { fetchJson } from '@/lib/fetchJson';
+
+interface QuoteItem {
+  id: string;
+  quoteNumber: string;
+  companyName: string;
+  contactName?: string | null;
+  status: string;
+  totalCents: number;
+  updatedAt: string;
+  createdAt: string;
+  customer?: { id: string; name: string } | null;
+  createdBy?: { id: string; name: string | null; email: string | null } | null;
+}
+
+interface ClientProps {
+  initial: { items: QuoteItem[]; nextCursor: string | null };
+}
+
+const formatCurrency = (cents: number) =>
+  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((cents || 0) / 100);
+
+const STATUS_LABELS: Record<string, string> = {
+  DRAFT: 'Draft',
+  SENT: 'Sent',
+  APPROVED: 'Approved',
+  EXPIRED: 'Expired',
+};
+
+export default function Client({ initial }: ClientProps) {
+  const [items, setItems] = useState<QuoteItem[]>(initial.items ?? []);
+  const [nextCursor, setNextCursor] = useState<string | null>(initial.nextCursor ?? null);
+  const [query, setQuery] = useState('');
+  const [status, setStatus] = useState('');
+  const toast = useToast();
+  const router = useRouter();
+
+  const columns = useMemo(
+    () => [
+      {
+        key: 'quoteNumber',
+        header: 'Quote',
+        render: (_: any, row: QuoteItem) => (
+          <Link href={`/admin/quotes/${row.id}`} className="font-medium text-primary hover:underline">
+            {row.quoteNumber}
+          </Link>
+        ),
+      },
+      {
+        key: 'companyName',
+        header: 'Company',
+        render: (value: string, row: QuoteItem) => (
+          <div className="flex flex-col">
+            <span className="font-medium">{value}</span>
+            {row.customer?.name && <span className="text-xs text-muted-foreground">Customer: {row.customer.name}</span>}
+          </div>
+        ),
+      },
+      {
+        key: 'contactName',
+        header: 'Contact',
+      },
+      {
+        key: 'status',
+        header: 'Status',
+        render: (value: string) => STATUS_LABELS[value] ?? value,
+      },
+      {
+        key: 'totalCents',
+        header: 'Total',
+        render: (value: number) => formatCurrency(value),
+      },
+      {
+        key: 'updatedAt',
+        header: 'Updated',
+        render: (value: string) => new Date(value).toLocaleDateString(),
+      },
+    ],
+    []
+  );
+
+  async function refresh(cursor?: string) {
+    const qs = new URLSearchParams();
+    if (query) qs.set('q', query);
+    if (status) qs.set('status', status);
+    if (cursor) qs.set('cursor', cursor);
+    const data = await fetchJson<{ items: QuoteItem[]; nextCursor: string | null }>(
+      `/api/admin/quotes?${qs.toString()}`
+    );
+    setItems(cursor ? [...items, ...(data.items ?? [])] : data.items ?? []);
+    setNextCursor(data.nextCursor ?? null);
+  }
+
+  async function remove(row: QuoteItem) {
+    await fetchJson(`/api/admin/quotes/${row.id}`, { method: 'DELETE' });
+    setItems(items.filter((i) => i.id !== row.id));
+    toast.push('Quote deleted', 'success');
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap items-center gap-3">
+        <Input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search by quote number, company, or contact"
+          className="w-full max-w-sm"
+        />
+        <select
+          value={status}
+          onChange={(event) => setStatus(event.target.value)}
+          className="rounded border border-border bg-background px-3 py-2 text-sm"
+        >
+          <option value="">All statuses</option>
+          <option value="DRAFT">Draft</option>
+          <option value="SENT">Sent</option>
+          <option value="APPROVED">Approved</option>
+          <option value="EXPIRED">Expired</option>
+        </select>
+        <Button variant="outline" onClick={() => refresh()}>
+          Search
+        </Button>
+        <div className="flex-1" />
+        <Button asChild>
+          <Link href="/admin/quotes/new">New quote</Link>
+        </Button>
+      </div>
+
+      <Table
+        columns={columns as any}
+        rows={items}
+        onEdit={(row) => router.push(`/admin/quotes/${row.id}`)}
+        onDelete={remove}
+      />
+
+      {nextCursor && (
+        <div className="flex justify-center">
+          <Button variant="outline" onClick={() => refresh(nextCursor)}>
+            Load more
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/quotes/new/page.tsx
+++ b/src/app/admin/quotes/new/page.tsx
@@ -1,0 +1,30 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import { ToastProvider } from '@/components/ui/Toast';
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import QuoteEditor from '../QuoteEditor';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewQuotePage() {
+  const session = await getServerSession(authOptions);
+  if (!session || !canAccessAdmin((session.user as any)?.role)) {
+    redirect('/');
+  }
+
+  return (
+    <div className="p-4 text-neutral-100 space-y-6">
+      <div>
+        <h1 className="text-xl font-semibold">Create quote</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Build a quote that can be printed or emailed to the customer. Pricing details stay private to admins.
+        </p>
+      </div>
+      <ToastProvider>
+        <QuoteEditor mode="create" />
+      </ToastProvider>
+    </div>
+  );
+}

--- a/src/app/admin/quotes/page.tsx
+++ b/src/app/admin/quotes/page.tsx
@@ -1,0 +1,44 @@
+import { redirect } from 'next/navigation';
+import { getServerSession } from 'next-auth';
+
+import NavTabs from '@/components/Admin/NavTabs';
+import { ToastProvider } from '@/components/ui/Toast';
+import { prisma } from '@/lib/prisma';
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import Client from './client';
+
+export const dynamic = 'force-dynamic';
+
+export default async function Page() {
+  const session = await getServerSession(authOptions);
+  if (!session || !canAccessAdmin((session.user as any)?.role)) {
+    redirect('/');
+  }
+
+  const items = await prisma.quote.findMany({
+    orderBy: { createdAt: 'desc' },
+    take: 20,
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+    },
+  });
+
+  const initial = { items, nextCursor: null };
+
+  return (
+    <div className="p-4 text-neutral-100">
+      <NavTabs />
+      <div className="mb-6">
+        <h1 className="text-xl font-semibold">Quotes</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Draft and send quotes for customers. Totals and cost breakdowns are only visible to administrators.
+        </p>
+      </div>
+      <ToastProvider>
+        <Client initial={initial} />
+      </ToastProvider>
+    </div>
+  );
+}

--- a/src/app/api/admin/addons/[id]/route.ts
+++ b/src/app/api/admin/addons/[id]/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { AddonPatch } from '@/lib/zod';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+  return { session };
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const body = await req.json();
+  const parsed = AddonPatch.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const data = parsed.data;
+  const item = await prisma.addon.update({ where: { id: params.id }, data });
+  return NextResponse.json({ ok: true, item });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  await prisma.addon.delete({ where: { id: params.id } });
+  return NextResponse.json({ ok: true });
+}
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const item = await prisma.addon.findUnique({ where: { id: params.id } });
+  if (!item) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+  return NextResponse.json({ item });
+}

--- a/src/app/api/admin/addons/route.ts
+++ b/src/app/api/admin/addons/route.ts
@@ -1,0 +1,81 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { AddonUpsert, ListQuery } from '@/lib/zod';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+  return { session };
+}
+
+const QuerySchema = ListQuery.extend({
+  active: z
+    .union([z.string().transform((value) => value === 'true'), z.boolean()])
+    .optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const { searchParams } = new URL(req.url);
+  const parsed = QuerySchema.safeParse({
+    q: searchParams.get('q') || undefined,
+    cursor: searchParams.get('cursor') || undefined,
+    take: searchParams.get('take') || undefined,
+    active: searchParams.get('active') || undefined,
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const { q, cursor, take, active } = parsed.data;
+  const where = {
+    ...(q
+      ? {
+          OR: [
+            { name: { contains: q, mode: 'insensitive' } },
+            { description: { contains: q, mode: 'insensitive' } },
+          ],
+        }
+      : {}),
+    ...(typeof active === 'boolean' ? { active } : {}),
+  };
+
+  const items = await prisma.addon.findMany({
+    where: Object.keys(where).length ? (where as any) : undefined,
+    orderBy: { name: 'asc' },
+    take: take + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+  const nextCursor = items.length > take ? items[take]?.id ?? null : null;
+  if (nextCursor) items.pop();
+  return NextResponse.json({ items, nextCursor });
+}
+
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const body = await req.json();
+  const parsed = AddonUpsert.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const data = parsed.data;
+  const item = await prisma.addon.create({ data });
+  return NextResponse.json({ ok: true, item });
+}

--- a/src/app/api/admin/quotes/[id]/route.ts
+++ b/src/app/api/admin/quotes/[id]/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { QuoteCreate } from '@/lib/zod-quotes';
+import { prepareQuoteComponents } from '@/lib/quotes.server';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+  return { session };
+}
+
+export async function GET(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const item = await prisma.quote.findUnique({
+    where: { id: params.id },
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      parts: true,
+      vendorItems: true,
+      addonSelections: {
+        include: {
+          addon: { select: { id: true, name: true, rateType: true, rateCents: true } },
+        },
+      },
+      attachments: true,
+    },
+  });
+
+  if (!item) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  return NextResponse.json({ item });
+}
+
+export async function DELETE(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  await prisma.quote.delete({ where: { id: params.id } });
+  return NextResponse.json({ ok: true });
+}
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const body = await req.json();
+  const parsed = QuoteCreate.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const existing = await prisma.quote.findUnique({ where: { id: params.id }, select: { quoteNumber: true } });
+  if (!existing) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  let prepared;
+  try {
+    prepared = await prepareQuoteComponents(parsed.data, { existingQuoteNumber: existing.quoteNumber });
+  } catch (error: any) {
+    const message = typeof error?.message === 'string' ? error.message : 'Failed to prepare quote';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const updated = await prisma.quote.update({
+    where: { id: params.id },
+    data: {
+      quoteNumber: prepared.quoteNumber,
+      companyName: parsed.data.companyName,
+      contactName: parsed.data.contactName ?? null,
+      contactEmail: parsed.data.contactEmail ?? null,
+      contactPhone: parsed.data.contactPhone ?? null,
+      customerId: parsed.data.customerId ?? null,
+      status: parsed.data.status ?? 'DRAFT',
+      materialSummary: parsed.data.materialSummary ?? null,
+      purchaseItems: parsed.data.purchaseItems ?? null,
+      requirements: parsed.data.requirements ?? null,
+      notes: parsed.data.notes ?? null,
+      multiPiece: prepared.multiPiece,
+      basePriceCents: prepared.basePriceCents,
+      vendorTotalCents: prepared.vendorTotalCents,
+      addonsTotalCents: prepared.addonsTotalCents,
+      totalCents: prepared.totalCents,
+      metadata: {
+        markupSuggestions: [0.1, 0.15, 0.2],
+      },
+      parts: {
+        deleteMany: {},
+        create: prepared.parts,
+      },
+      vendorItems: {
+        deleteMany: {},
+        create: prepared.vendorItems,
+      },
+      addonSelections: {
+        deleteMany: {},
+        create: prepared.addonSelections,
+      },
+      attachments: {
+        deleteMany: {},
+        create: prepared.attachments,
+      },
+    },
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      parts: true,
+      vendorItems: true,
+      addonSelections: {
+        include: { addon: { select: { id: true, name: true, rateType: true, rateCents: true } } },
+      },
+      attachments: true,
+    },
+  });
+
+  return NextResponse.json({ ok: true, item: updated });
+}

--- a/src/app/api/admin/quotes/route.ts
+++ b/src/app/api/admin/quotes/route.ts
@@ -1,0 +1,150 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+import { ListQuery } from '@/lib/zod';
+import { QuoteCreate } from '@/lib/zod-quotes';
+import { prepareQuoteComponents } from '@/lib/quotes.server';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+  return { session };
+}
+
+const QuerySchema = ListQuery.extend({
+  status: z.string().trim().optional(),
+  customerId: z.string().trim().optional(),
+});
+
+export async function GET(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const { searchParams } = new URL(req.url);
+  const parsed = QuerySchema.safeParse({
+    q: searchParams.get('q') || undefined,
+    cursor: searchParams.get('cursor') || undefined,
+    take: searchParams.get('take') || undefined,
+    status: searchParams.get('status') || undefined,
+    customerId: searchParams.get('customerId') || undefined,
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const { q, cursor, take, status, customerId } = parsed.data;
+
+  const where: any = {};
+  if (q) {
+    where.OR = [
+      { quoteNumber: { contains: q, mode: 'insensitive' } },
+      { companyName: { contains: q, mode: 'insensitive' } },
+      { contactName: { contains: q, mode: 'insensitive' } },
+    ];
+  }
+  if (status) where.status = status;
+  if (customerId) where.customerId = customerId;
+
+  const items = await prisma.quote.findMany({
+    where: Object.keys(where).length ? where : undefined,
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+    },
+    orderBy: { createdAt: 'desc' },
+    take: take + 1,
+    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
+  });
+  const nextCursor = items.length > take ? items[take]?.id ?? null : null;
+  if (nextCursor) items.pop();
+
+  return NextResponse.json({ items, nextCursor });
+}
+
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+  const session = guard.session;
+
+  const body = await req.json();
+  const parsed = QuoteCreate.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.message }, { status: 400 });
+  }
+
+  const data = parsed.data;
+  const userId = (session.user as any)?.id;
+  if (!userId) {
+    return NextResponse.json({ error: 'Unable to determine current user' }, { status: 400 });
+  }
+
+  let prepared;
+  try {
+    prepared = await prepareQuoteComponents(data);
+  } catch (error: any) {
+    const message = typeof error?.message === 'string' ? error.message : 'Failed to prepare quote';
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+
+  const created = await prisma.quote.create({
+    data: {
+      quoteNumber: prepared.quoteNumber,
+      companyName: data.companyName,
+      contactName: data.contactName ?? null,
+      contactEmail: data.contactEmail ?? null,
+      contactPhone: data.contactPhone ?? null,
+      customerId: data.customerId ?? null,
+      status: data.status ?? 'DRAFT',
+      materialSummary: data.materialSummary ?? null,
+      purchaseItems: data.purchaseItems ?? null,
+      requirements: data.requirements ?? null,
+      notes: data.notes ?? null,
+      multiPiece: prepared.multiPiece,
+      basePriceCents: prepared.basePriceCents,
+      addonsTotalCents: prepared.addonsTotalCents,
+      vendorTotalCents: prepared.vendorTotalCents,
+      totalCents: prepared.totalCents,
+      metadata: {
+        markupSuggestions: [0.1, 0.15, 0.2],
+      },
+      createdById: userId,
+      parts: {
+        create: prepared.parts,
+      },
+      vendorItems: {
+        create: prepared.vendorItems,
+      },
+      addonSelections: {
+        create: prepared.addonSelections,
+      },
+      attachments: {
+        create: prepared.attachments,
+      },
+    },
+    include: {
+      customer: { select: { id: true, name: true } },
+      createdBy: { select: { id: true, name: true, email: true } },
+      parts: true,
+      vendorItems: true,
+      addonSelections: {
+        include: {
+          addon: { select: { id: true, name: true, rateType: true, rateCents: true } },
+        },
+      },
+      attachments: true,
+    },
+  });
+
+  return NextResponse.json({ ok: true, item: created });
+}

--- a/src/components/Admin/NavTabs.tsx
+++ b/src/components/Admin/NavTabs.tsx
@@ -10,6 +10,8 @@ const tabs = [
   { href: '/admin/materials', label: 'Materials' },
   { href: '/admin/vendors', label: 'Vendors' },
   { href: '/admin/checklist', label: 'Checklist' },
+  { href: '/admin/addons', label: 'Add-ons' },
+  { href: '/admin/quotes', label: 'Quotes' },
 ];
 
 export default function NavTabs() {

--- a/src/lib/quotes.server.ts
+++ b/src/lib/quotes.server.ts
@@ -1,0 +1,162 @@
+import { prisma } from '@/lib/prisma';
+import { QuoteCreateInput } from './zod-quotes';
+
+export async function generateQuoteNumber() {
+  const now = new Date();
+  const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
+  for (let attempt = 0; attempt < 5; attempt += 1) {
+    const candidate = `Q-${stamp}-${Math.floor(Math.random() * 10000)
+      .toString()
+      .padStart(4, '0')}`;
+    const existing = await prisma.quote.findUnique({ where: { quoteNumber: candidate } });
+    if (!existing) {
+      return candidate;
+    }
+  }
+  return `Q-${stamp}-${Date.now()}`;
+}
+
+export interface PreparedQuoteComponents {
+  quoteNumber: string;
+  multiPiece: boolean;
+  basePriceCents: number;
+  vendorTotalCents: number;
+  addonsTotalCents: number;
+  totalCents: number;
+  parts: Array<{
+    name: string;
+    description: string | null;
+    quantity: number;
+    pieceCount: number;
+    notes: string | null;
+  }>;
+  vendorItems: Array<{
+    vendorId: string | null;
+    vendorName: string | null;
+    partNumber: string | null;
+    partUrl: string | null;
+    basePriceCents: number;
+    markupPercent: number;
+    finalPriceCents: number;
+    notes: string | null;
+  }>;
+  addonSelections: Array<{
+    addonId: string;
+    units: number;
+    rateTypeSnapshot: string;
+    rateCents: number;
+    totalCents: number;
+    notes: string | null;
+  }>;
+  attachments: Array<{
+    url: string;
+    label: string | null;
+    mimeType: string | null;
+  }>;
+}
+
+export async function prepareQuoteComponents(
+  input: QuoteCreateInput,
+  options?: { existingQuoteNumber?: string }
+): Promise<PreparedQuoteComponents> {
+  const parts = input.parts ?? [];
+  const vendorItemsInput = input.vendorItems ?? [];
+  const addonSelectionsInput = input.addonSelections ?? [];
+  const attachmentsInput = input.attachments ?? [];
+
+  const vendorIds = vendorItemsInput
+    .map((item) => item.vendorId)
+    .filter((value): value is string => typeof value === 'string' && value.length > 0);
+  type VendorRecord = { id: string; name?: string | null };
+  const vendorRecords: VendorRecord[] = vendorIds.length
+    ? ((await prisma.vendor.findMany({ where: { id: { in: vendorIds } } })) as VendorRecord[])
+    : [];
+  const vendorMap = new Map(vendorRecords.map((vendor) => [vendor.id, vendor]));
+
+  type AddonRecord = { id: string; name: string; rateType: string; rateCents: number };
+  const addonIds = addonSelectionsInput.map((item) => item.addonId);
+  const addonRecords: AddonRecord[] = addonIds.length
+    ? ((await prisma.addon.findMany({ where: { id: { in: addonIds } } })) as AddonRecord[])
+    : [];
+  const addonMap = new Map(addonRecords.map((addon) => [addon.id, addon]));
+
+  for (const selection of addonSelectionsInput) {
+    if (!addonMap.has(selection.addonId)) {
+      throw new Error(`Addon ${selection.addonId} not found`);
+    }
+  }
+
+  const addonSelections = addonSelectionsInput.map((item) => {
+    const addon = addonMap.get(item.addonId)!;
+    const units = typeof item.units === 'number' ? item.units : 0;
+    const totalCents = Math.round(addon.rateCents * units);
+    return {
+      addonId: addon.id,
+      units,
+      rateTypeSnapshot: addon.rateType,
+      rateCents: addon.rateCents,
+      totalCents,
+      notes: item.notes ?? null,
+    };
+  });
+
+  const addonsTotalCents = addonSelections.reduce((sum, selection) => sum + selection.totalCents, 0);
+
+  const vendorItems = vendorItemsInput.map((item) => {
+    const vendor = item.vendorId ? vendorMap.get(item.vendorId) : undefined;
+    const basePriceCents = item.basePriceCents ?? 0;
+    const markupPercent = item.markupPercent ?? 0;
+    const calculatedFinal = Math.round(basePriceCents * (1 + markupPercent / 100));
+    const finalPriceCents = item.finalPriceCents && item.finalPriceCents > 0 ? item.finalPriceCents : calculatedFinal;
+    return {
+      vendorId: item.vendorId ?? null,
+      vendorName: item.vendorName ?? vendor?.name ?? null,
+      partNumber: item.partNumber ?? null,
+      partUrl: item.partUrl ?? null,
+      basePriceCents,
+      markupPercent,
+      finalPriceCents,
+      notes: item.notes ?? null,
+    };
+  });
+
+  const vendorTotalCents = vendorItems.reduce((sum, item) => sum + item.finalPriceCents, 0);
+  const basePriceCents = input.basePriceCents ?? 0;
+  const totalCents = basePriceCents + vendorTotalCents + addonsTotalCents;
+
+  const quoteNumber = input.quoteNumber && input.quoteNumber.trim().length > 0
+    ? input.quoteNumber.trim()
+    : options?.existingQuoteNumber ?? (await generateQuoteNumber());
+
+  const multiPiece =
+    typeof input.multiPiece === 'boolean'
+      ? input.multiPiece
+      : parts.some((part) => (part.pieceCount ?? 1) > 1);
+
+  const partsData = parts.map((part) => ({
+    name: part.name,
+    description: part.description ?? null,
+    quantity: part.quantity ?? 1,
+    pieceCount: part.pieceCount ?? 1,
+    notes: part.notes ?? null,
+  }));
+
+  const attachments = attachmentsInput.map((attachment) => ({
+    url: attachment.url,
+    label: attachment.label ?? null,
+    mimeType: attachment.mimeType ?? null,
+  }));
+
+  return {
+    quoteNumber,
+    multiPiece,
+    basePriceCents,
+    vendorTotalCents,
+    addonsTotalCents,
+    totalCents,
+    parts: partsData,
+    vendorItems,
+    addonSelections,
+    attachments,
+  };
+}

--- a/src/lib/zod-quotes.ts
+++ b/src/lib/zod-quotes.ts
@@ -1,0 +1,61 @@
+import { z } from 'zod';
+
+export const QuotePartInput = z.object({
+  name: z.string().trim().min(1).max(200),
+  description: z.string().trim().max(2000).optional(),
+  quantity: z.coerce.number().int().min(1).default(1),
+  pieceCount: z.coerce.number().int().min(1).default(1),
+  notes: z.string().trim().max(2000).optional(),
+});
+
+export const QuoteVendorItemInput = z.object({
+  vendorId: z.string().trim().max(100).optional(),
+  vendorName: z.string().trim().max(200).optional(),
+  partNumber: z.string().trim().max(200).optional(),
+  partUrl: z.string().trim().max(500).optional(),
+  basePriceCents: z.coerce.number().int().min(0).default(0),
+  markupPercent: z.coerce.number().min(0).max(1000).default(0),
+  finalPriceCents: z.coerce.number().int().min(0).default(0),
+  notes: z.string().trim().max(2000).optional(),
+});
+
+export const QuoteAddonSelectionInput = z.object({
+  addonId: z.string().trim().min(1),
+  units: z.coerce.number().min(0).default(0),
+  notes: z.string().trim().max(2000).optional(),
+});
+
+export const QuoteAttachmentInput = z.object({
+  url: z.string().trim().min(1).max(500),
+  label: z.string().trim().max(200).optional(),
+  mimeType: z.string().trim().max(200).optional(),
+});
+
+export const QuoteCreate = z.object({
+  quoteNumber: z.string().trim().max(50).optional(),
+  companyName: z.string().trim().min(1).max(200),
+  contactName: z.string().trim().max(200).optional(),
+  contactEmail: z.string().trim().email().max(200).optional(),
+  contactPhone: z.string().trim().max(50).optional(),
+  customerId: z.string().trim().optional(),
+  status: z.string().trim().max(40).default('DRAFT'),
+  materialSummary: z.string().trim().max(4000).optional(),
+  purchaseItems: z.string().trim().max(4000).optional(),
+  requirements: z.string().trim().max(4000).optional(),
+  notes: z.string().trim().max(4000).optional(),
+  multiPiece: z.boolean().optional(),
+  basePriceCents: z.coerce.number().int().min(0).default(0),
+  parts: z.array(QuotePartInput).default([]),
+  vendorItems: z.array(QuoteVendorItemInput).default([]),
+  addonSelections: z.array(QuoteAddonSelectionInput).default([]),
+  attachments: z.array(QuoteAttachmentInput).default([]),
+});
+
+export const QuoteUpdate = QuoteCreate.partial();
+
+export type QuoteCreateInput = z.infer<typeof QuoteCreate>;
+export type QuoteUpdateInput = z.infer<typeof QuoteUpdate>;
+export type QuotePartInputType = z.infer<typeof QuotePartInput>;
+export type QuoteVendorItemInputType = z.infer<typeof QuoteVendorItemInput>;
+export type QuoteAddonSelectionInputType = z.infer<typeof QuoteAddonSelectionInput>;
+export type QuoteAttachmentInputType = z.infer<typeof QuoteAttachmentInput>;

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -48,6 +48,17 @@ export const ChecklistItemUpsert = z.object({
 });
 export const ChecklistItemPatch = ChecklistItemUpsert.partial();
 
+/** ADDONS */
+export const AddonRateType = z.enum(['HOURLY', 'FLAT']);
+export const AddonUpsert = z.object({
+  name: z.string().trim().min(2).max(120),
+  description: z.string().trim().max(1000).optional(),
+  rateType: AddonRateType.default('HOURLY'),
+  rateCents: z.coerce.number().int().min(0).max(10_000_000),
+  active: z.boolean().default(true),
+});
+export const AddonPatch = AddonUpsert.partial();
+
 /** Common query schema for list endpoints: ?q=&cursor=&take= */
 export const ListQuery = z.object({
   q: Q,
@@ -65,3 +76,5 @@ export type TVendorPatch = z.infer<typeof VendorPatch>;
 export type TChecklistItemUpsert = z.infer<typeof ChecklistItemUpsert>;
 export type TChecklistItemPatch = z.infer<typeof ChecklistItemPatch>;
 export type TListQuery = z.infer<typeof ListQuery>;
+export type TAddonUpsert = z.infer<typeof AddonUpsert>;
+export type TAddonPatch = z.infer<typeof AddonPatch>;


### PR DESCRIPTION
## Summary
- extend the Prisma schema and seed data with add-ons and quotes so pricing can be tracked per quote
- add admin CRUD APIs and UI screens for managing add-ons as well as listing, creating, editing, and printing quotes
- build a rich quote editor that captures parts, purchased items, labor add-ons, attachments, and totals while keeping pricing private to admins

## Testing
- pnpm tsc --noEmit
- pnpm prisma generate *(fails in container: Prisma engine download forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68d6132cf9408327a2e7840eeef527fd