### PR TITLE
Fix Prisma SQLite schema incompatibilities

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,7 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// NOTE: No enums on SQLite. Use strings + @db.Text instead.
+// NOTE: No enums on SQLite. Use strings instead.
 
 model User {
   id               String   @id @default(cuid())
@@ -167,7 +167,7 @@ model StatusHistory {
 model Addon {
   id          String   @id @default(cuid())
   name        String
-  description String? @db.Text
+  description String?
   rateType    String
   rateCents   Int
   active      Boolean  @default(true)
@@ -191,16 +191,16 @@ model Quote {
   customerId       String?
   customer         Customer? @relation(fields: [customerId], references: [id])
   status           String    @default("DRAFT")
-  materialSummary  String?   @db.Text
-  purchaseItems    String?   @db.Text
-  requirements     String?   @db.Text
-  notes            String?   @db.Text
+  materialSummary  String?
+  purchaseItems    String?
+  requirements     String?
+  notes            String?
   multiPiece       Boolean   @default(false)
   basePriceCents   Int       @default(0)
   addonsTotalCents Int       @default(0)
   vendorTotalCents Int       @default(0)
   totalCents       Int       @default(0)
-  metadata         Json?
+  metadata         String?
 
   createdById String
   createdBy   User     @relation(fields: [createdById], references: [id])
@@ -223,10 +223,10 @@ model QuotePart {
   quoteId    String
   quote      Quote  @relation(fields: [quoteId], references: [id], onDelete: Cascade)
   name       String
-  description String? @db.Text
+  description String?
   quantity   Int    @default(1)
   pieceCount Int    @default(1)
-  notes      String? @db.Text
+  notes      String?
 }
 
 model QuoteVendorItem {
@@ -241,7 +241,7 @@ model QuoteVendorItem {
   basePriceCents  Int     @default(0)
   markupPercent   Float   @default(0)
   finalPriceCents Int     @default(0)
-  notes           String? @db.Text
+  notes           String?
 }
 
 model QuoteAddonSelection {
@@ -254,7 +254,7 @@ model QuoteAddonSelection {
   rateTypeSnapshot String
   rateCents        Int
   totalCents       Int
-  notes            String? @db.Text
+  notes            String?
 }
 
 model QuoteAttachment {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,7 @@
 import { PrismaClient } from '@prisma/client';
 
+import { DEFAULT_QUOTE_METADATA, stringifyQuoteMetadata } from '../src/lib/quote-metadata';
+
 const prisma = new PrismaClient();
 
 async function main() {
@@ -192,9 +194,10 @@ async function main() {
         multiPiece: true,
         notes: 'Initial quote prepared from legacy spreadsheet.',
         createdById: admin.id,
-        metadata: {
+        metadata: stringifyQuoteMetadata({
+          ...DEFAULT_QUOTE_METADATA,
           markupNotes: 'Vendor markup applied at 20%. Labor captured via addons.',
-        },
+        }),
         parts: {
           create: [
             {

--- a/src/lib/quote-metadata.ts
+++ b/src/lib/quote-metadata.ts
@@ -1,0 +1,32 @@
+export type QuoteMetadata = Record<string, unknown> & {
+  markupSuggestions?: number[];
+};
+
+export const DEFAULT_QUOTE_METADATA: QuoteMetadata = Object.freeze({
+  markupSuggestions: [0.1, 0.15, 0.2],
+});
+
+export function stringifyQuoteMetadata(metadata: QuoteMetadata | null | undefined): string | null {
+  if (!metadata) {
+    return null;
+  }
+
+  try {
+    return JSON.stringify(metadata);
+  } catch {
+    return null;
+  }
+}
+
+export function parseQuoteMetadata(value: string | null | undefined): QuoteMetadata | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === 'object' ? (parsed as QuoteMetadata) : null;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## Summary
- replace SQLite-incompatible native type annotations with standard strings in the Prisma schema
- store quote metadata as text while providing helper utilities to serialize and parse it consistently
- update seed data and quote API endpoints to keep metadata responses JSON-compatible for clients

## Testing
- PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma generate *(fails: Prisma engine download returns 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d61afd959c83278fa8380c583c69a8