### PR TITLE
feat: add local attachment storage helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules/
 .next/
 dist/
+storage/
 *.log
 /.env
 cookies.txt

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ What you get
 	•	Customers: Corning, Toyota, Acme Fab
 	•	Orders: 3 sample POs with parts, checklist rows, history, notes, timelogs, attachments
 
+## Attachment storage
+
+- Attachments are stored on disk underneath the directory defined by the
+  `ATTACHMENTS_DIR` environment variable. If it is not set, the application
+  defaults to a local `storage/` folder in the project root.
+- `npm install` / `pnpm install` automatically run `scripts/init-storage.ts` to
+  create the attachment root and top-level folders for each business (Sterling
+  Tool and Die, C and R Machining, Powder Coating).
+- Attachments are saved using slugified directory names in the format
+  `<business>/<customer>/<reference>/`. For example, an order for "Acme Co" with
+  reference `PO-1234` under Sterling Tool and Die will live at
+  `storage/sterling-tool-and-die/acme-co/po-1234/` by default.
+- Override `ATTACHMENTS_DIR` at runtime or during installation to point to a
+  different root location, and rerun `pnpm ts-node --esm scripts/init-storage.ts`
+  if you need to recreate the initial structure manually.
+
 Switch to MySQL (optional)
 	1.	In datasource db set provider = "mysql" and set DATABASE_URL in .env.
 	2.	Run:

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "set-demo-passwords": "node scripts/set-demo-passwords.js",
     "demo:setup": "npm run seed && npm run set-demo-passwords",
     "auto-commit": "node scripts/auto-commit.js",
-    "postinstall": "node scripts/check-path-casing.js"
+    "postinstall": "node scripts/check-path-casing.js && ts-node --esm scripts/init-storage.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.18.0",

--- a/scripts/init-storage.ts
+++ b/scripts/init-storage.ts
@@ -1,0 +1,26 @@
+import path from 'node:path';
+import { mkdir } from 'node:fs/promises';
+
+import {
+  BUSINESS_OPTIONS,
+  ensureAttachmentRoot,
+} from '../src/lib/storage';
+
+async function main() {
+  const rootDir = await ensureAttachmentRoot();
+
+  for (const option of BUSINESS_OPTIONS) {
+    const businessDir = path.join(rootDir, option.slug);
+    await mkdir(businessDir, { recursive: true });
+  }
+
+  console.log(
+    `[storage] Initialized attachment directories under "${rootDir}".`,
+  );
+}
+
+main().catch((error) => {
+  console.error('[storage] Failed to initialize attachment directories.');
+  console.error(error);
+  process.exit(1);
+});

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,77 @@
+import path from 'node:path';
+import { mkdir } from 'node:fs/promises';
+
+export const ATTACHMENTS_ROOT = process.env.ATTACHMENTS_DIR ?? 'storage';
+
+export const BUSINESS_NAMES = [
+  'Sterling Tool and Die',
+  'C and R Machining',
+  'Powder Coating',
+] as const;
+
+export type BusinessName = (typeof BUSINESS_NAMES)[number];
+
+export interface BusinessOption {
+  name: BusinessName;
+  slug: string;
+}
+
+export function slugifyName(
+  value: string | null | undefined,
+  fallback = 'item',
+): string {
+  const base = value?.toString().trim() ?? '';
+  const normalized = base
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '');
+
+  const slug = normalized
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/-{2,}/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+  return slug || fallback;
+}
+
+export const BUSINESS_OPTIONS = BUSINESS_NAMES.map((name) => ({
+  name,
+  slug: slugifyName(name, 'business'),
+})) as const satisfies readonly BusinessOption[];
+
+export async function ensureAttachmentRoot(
+  rootDir: string = ATTACHMENTS_ROOT,
+): Promise<string> {
+  const absoluteRoot = path.resolve(rootDir);
+  await mkdir(absoluteRoot, { recursive: true });
+  return absoluteRoot;
+}
+
+export interface AttachmentPathInfo {
+  relativeDirectory: string;
+  absoluteDirectory: string;
+}
+
+export async function buildAttachmentPath(
+  business: BusinessName,
+  customerName: string,
+  referenceNumber: string,
+  rootDir: string = ATTACHMENTS_ROOT,
+): Promise<AttachmentPathInfo> {
+  const absoluteRoot = await ensureAttachmentRoot(rootDir);
+  const businessSlug = slugifyName(business, 'business');
+  const customerSlug = slugifyName(customerName, 'customer');
+  const referenceSlug = slugifyName(referenceNumber, 'reference');
+
+  const relativeDirectory = [businessSlug, customerSlug, referenceSlug].join('/');
+  const absoluteDirectory = path.join(
+    absoluteRoot,
+    businessSlug,
+    customerSlug,
+    referenceSlug,
+  );
+
+  await mkdir(absoluteDirectory, { recursive: true });
+
+  return { relativeDirectory, absoluteDirectory };
+}


### PR DESCRIPTION
## Summary
- add filesystem storage helpers to create predictable business/customer/reference folders
- initialize the attachment directory tree during installation and document ATTACHMENTS_DIR usage
- ignore the generated storage root from version control

## Testing
- not run (Node.js runtime is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68da81f8a0748327aaac22bdc1692600