### PR TITLE
Add filesystem-backed uploads for order attachments

### DIFF
--- a/README-PATCH-4A.md
+++ b/README-PATCH-4A.md
@@ -9,3 +9,9 @@ Usage:
 - `POST /api/orders` — Admin only; JSON body includes order meta, parts, optional checklist seeding, and attachments.
 
 This patch doesn't touch existing files; safe to merge into Phase 1–3 baseline.
+
+## Attachments storage
+
+Orders now store uploaded files on the shared filesystem. Refer to
+[`docs/order-attachments-migration.md`](docs/order-attachments-migration.md) for guidance on migrating
+legacy base64 attachments into the new directory structure.

--- a/docs/order-attachments-migration.md
+++ b/docs/order-attachments-migration.md
@@ -1,0 +1,20 @@
+# Order Attachment Migration Guide
+
+The orders API previously stored uploaded files as large base64 data URLs inside the `Attachment.url` column.
+The new shared-storage integration expects uploaded files to live on disk with their `storagePath` recorded
+in the database. Existing data URL records will continue to render, but the inlined payloads are inefficient
+and cannot take advantage of the new download endpoint. Use the following steps to migrate legacy records:
+
+1. **Identify embedded files.** Run a query such as `SELECT id, order_id, label FROM "Attachment" WHERE url LIKE 'data:%';`
+   to list attachments that still contain base64 content.
+2. **Export the binary data.** For each result, parse the `url` to strip the `data:mimetype;base64,` prefix and
+   decode the remainder into a `Buffer`. Persist the decoded file to disk using the helper in `src/lib/storage.ts`
+   (`storeAttachmentFile`) with the appropriate business, customer name, and order number.
+3. **Update the database.** After writing the file, update the row by setting `storagePath` to the returned path and
+   clearing `url` (or replacing it with an external link if you prefer to keep a hosted copy).
+4. **Verify access.** Confirm that `/attachments/<storagePath>` responds with the expected file via the new download
+   route, and that the order detail page shows the attachment as “Stored”.
+
+Because the migration requires business, customer, and order context, perform the export with a script that joins
+on `Order` and `Customer` to gather names before calling `storeAttachmentFile`. Once every record has a
+`storagePath`, you may optionally trim the oversized base64 data and reclaim storage space.

--- a/prisma/migrations/20251012120000_add_attachment_storage_path/migration.sql
+++ b/prisma/migrations/20251012120000_add_attachment_storage_path/migration.sql
@@ -1,0 +1,25 @@
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "Attachment_new" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "orderId" TEXT NOT NULL,
+    "url" TEXT,
+    "storagePath" TEXT,
+    "label" TEXT,
+    "mimeType" TEXT,
+    "uploadedById" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Attachment_orderId_fkey" FOREIGN KEY ("orderId") REFERENCES "Order" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Attachment_uploadedById_fkey" FOREIGN KEY ("uploadedById") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+
+INSERT INTO "Attachment_new" ("id", "orderId", "url", "storagePath", "label", "mimeType", "uploadedById", "createdAt")
+SELECT "id", "orderId", "url", NULL, "label", "mimeType", "uploadedById", "createdAt"
+FROM "Attachment";
+
+DROP TABLE "Attachment";
+ALTER TABLE "Attachment_new" RENAME TO "Attachment";
+
+CREATE INDEX "Attachment_storagePath_idx" ON "Attachment"("storagePath");
+
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -140,12 +140,15 @@ model Attachment {
   id        String   @id @default(cuid())
   orderId   String
   order     Order    @relation(fields: [orderId], references: [id])
-  url       String
+  url       String?
+  storagePath String?
   label     String?
   mimeType  String?
   uploadedById String?
   uploadedBy   User? @relation("UserAttachments", fields: [uploadedById], references: [id])
   createdAt DateTime @default(now())
+
+  @@index([storagePath])
 }
 
 model StatusHistory {

--- a/src/app/(public)/attachments/[...path]/route.ts
+++ b/src/app/(public)/attachments/[...path]/route.ts
@@ -14,10 +14,19 @@ export async function GET(_req: NextRequest, { params }: { params: { path: strin
   }
 
   const relativePath = segments.join('/');
-  const attachment = await prisma.quoteAttachment.findFirst({
+  const quoteAttachment = await prisma.quoteAttachment.findFirst({
     where: { storagePath: relativePath },
     select: { mimeType: true, label: true },
   });
+
+  const orderAttachment = quoteAttachment
+    ? null
+    : await prisma.attachment.findFirst({
+        where: { storagePath: relativePath },
+        select: { mimeType: true, label: true },
+      });
+
+  const attachment = quoteAttachment ?? orderAttachment;
 
   if (!attachment) {
     return new NextResponse('Not found', { status: 404 });

--- a/src/app/api/orders/[id]/attachments/route.ts
+++ b/src/app/api/orders/[id]/attachments/route.ts
@@ -32,7 +32,8 @@ export async function POST(req: NextRequest, { params }: { params: { id: string 
   const attachment = await prisma.attachment.create({
     data: {
       orderId: id,
-      url: payload.url,
+      url: payload.url ?? null,
+      storagePath: payload.storagePath ?? null,
       label: payload.label?.length ? payload.label : null,
       mimeType: payload.mimeType?.length ? payload.mimeType : null,
       uploadedById: userId ?? null,

--- a/src/app/api/orders/attachments/upload/route.ts
+++ b/src/app/api/orders/attachments/upload/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+import { canAccessAdmin } from '@/lib/rbac';
+import { BUSINESS_NAMES, storeAttachmentFile, type BusinessName } from '@/lib/storage';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  return { session };
+}
+
+function parseBusiness(value: FormDataEntryValue | null): BusinessName | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  if (!normalized) return null;
+  if ((BUSINESS_NAMES as readonly string[]).includes(normalized)) {
+    return normalized as BusinessName;
+  }
+  return null;
+}
+
+function extractString(value: FormDataEntryValue | null): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+export async function POST(req: NextRequest) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const form = await req.formData();
+  const file = form.get('file');
+  if (!(file instanceof File)) {
+    return NextResponse.json({ error: 'Missing file upload' }, { status: 400 });
+  }
+
+  const business = parseBusiness(form.get('business'));
+  if (!business) {
+    return NextResponse.json({ error: 'Invalid business selection' }, { status: 400 });
+  }
+
+  const customerName = extractString(form.get('customerName'));
+  const orderReference = extractString(form.get('orderReference'));
+
+  if (!customerName) {
+    return NextResponse.json({ error: 'Customer name is required for uploads' }, { status: 400 });
+  }
+
+  if (!orderReference) {
+    return NextResponse.json({ error: 'Order reference is required for uploads' }, { status: 400 });
+  }
+
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = Buffer.from(arrayBuffer);
+
+  try {
+    const stored = await storeAttachmentFile({
+      business,
+      customerName,
+      referenceNumber: orderReference,
+      originalFilename: file.name,
+      buffer,
+    });
+
+    return NextResponse.json({
+      storagePath: stored.storagePath,
+      label: file.name,
+      mimeType: file.type || null,
+    });
+  } catch (error: any) {
+    const message = typeof error?.message === 'string' ? error.message : 'Failed to store attachment';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/orders/route.ts
+++ b/src/app/api/orders/route.ts
@@ -117,7 +117,8 @@ export async function POST(req: NextRequest) {
       attachments: body.attachments.length
         ? {
             create: body.attachments.map(a => ({
-              url: a.url,
+              url: a.url ?? null,
+              storagePath: a.storagePath ?? null,
               label: a.label ?? null,
               mimeType: a.mimeType ?? null,
               uploadedById: (session.user as any)?.id ?? null,

--- a/src/app/orders/new/page.tsx
+++ b/src/app/orders/new/page.tsx
@@ -33,9 +33,17 @@ import {
   DialogTitle,
   DialogTrigger,
 } from '@/components/ui/dialog';
+import { BUSINESS_OPTIONS, slugifyName, type BusinessName } from '@/lib/businesses';
 
 const priorities = ['LOW', 'NORMAL', 'RUSH', 'HOT'];
 const OPTIONAL_VALUE = '__none__';
+
+const createKey = () =>
+  typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+    ? crypto.randomUUID()
+    : Math.random().toString(36).slice(2);
+
+const DEFAULT_BUSINESS = (BUSINESS_OPTIONS[0]?.name ?? 'Sterling Tool and Die') as BusinessName;
 
 type Option = { id: string; name: string };
 type AddonOption = {
@@ -47,10 +55,10 @@ type AddonOption = {
   active: boolean;
 };
 type PartInput = { partNumber: string; quantity: number; materialId?: string; notes?: string };
-type AttachmentInput = { url: string; label: string; mimeType?: string };
+type AttachmentInput = { url: string; storagePath: string; label: string; mimeType: string; uploading?: boolean };
 
 const emptyPart = (): PartInput => ({ partNumber: '', quantity: 1, materialId: '', notes: '' });
-const emptyAttachment = (): AttachmentInput => ({ url: '', label: '', mimeType: '' });
+const emptyAttachment = (): AttachmentInput => ({ url: '', storagePath: '', label: '', mimeType: '', uploading: false });
 
 export default function NewOrderPage() {
   const [customerId, setCustomerId] = React.useState('');
@@ -73,6 +81,8 @@ export default function NewOrderPage() {
   const [priority, setPriority] = React.useState('NORMAL');
   const [parts, setParts] = React.useState<PartInput[]>([emptyPart()]);
   const [attachments, setAttachments] = React.useState<AttachmentInput[]>([emptyAttachment()]);
+  const [attachmentBusiness, setAttachmentBusiness] = React.useState<BusinessName>(DEFAULT_BUSINESS);
+  const [draftAttachmentReference] = React.useState(() => createKey());
   const [materialNeeded, setMaterialNeeded] = React.useState(false);
   const [materialOrdered, setMaterialOrdered] = React.useState(false);
   const [modelIncluded, setModelIncluded] = React.useState(false);
@@ -168,6 +178,20 @@ export default function NewOrderPage() {
     })();
   }, []);
 
+  const selectedBusinessOption = React.useMemo(
+    () => BUSINESS_OPTIONS.find((option) => option.name === attachmentBusiness) ?? BUSINESS_OPTIONS[0],
+    [attachmentBusiness],
+  );
+
+  const attachmentPathPreview = React.useMemo(() => {
+    const businessSlug = selectedBusinessOption?.slug ?? 'business';
+    const customerName = customers.find((c) => c.id === customerId)?.name ?? '';
+    const customerSlug = slugifyName(customerName, 'customer') || 'customer';
+    const referenceValue = (poNumber || '').trim() || draftAttachmentReference;
+    const referenceSlug = slugifyName(referenceValue, 'order');
+    return `${businessSlug}/${customerSlug || 'customer'}/${referenceSlug}`;
+  }, [customerId, customers, draftAttachmentReference, poNumber, selectedBusinessOption]);
+
   function updatePart(index: number, patch: Partial<PartInput>) {
     setParts((prev) => prev.map((part, i) => (i === index ? { ...part, ...patch } : part)));
   }
@@ -184,6 +208,20 @@ export default function NewOrderPage() {
     setAttachments((prev) => prev.map((att, i) => (i === index ? { ...att, ...patch } : att)));
   }
 
+  function handleAttachmentUrlChange(index: number, value: string) {
+    setAttachments((prev) =>
+      prev.map((att, i) =>
+        i === index
+          ? {
+              ...att,
+              url: value,
+              storagePath: value.trim().length ? '' : att.storagePath,
+            }
+          : att,
+      ),
+    );
+  }
+
   function addAttachmentRow() {
     setAttachments((prev) => [...prev, emptyAttachment()]);
   }
@@ -192,19 +230,78 @@ export default function NewOrderPage() {
     setAttachments((prev) => (prev.length === 1 ? prev : prev.filter((_, i) => i !== index)));
   }
 
-  function handleAttachmentFile(index: number, fileList: FileList | null) {
+  async function handleAttachmentFile(index: number, fileList: FileList | null) {
     const file = fileList?.[0];
     if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      const result = typeof reader.result === 'string' ? reader.result : '';
-      updateAttachment(index, {
-        url: result,
-        label: attachments[index]?.label || file.name,
-        mimeType: file.type || attachments[index]?.mimeType,
+
+    const customerName = customers.find((customer) => customer.id === customerId)?.name?.trim() ?? '';
+    if (!customerName) {
+      setMessage('Select a customer before uploading attachments.');
+      return;
+    }
+
+    const orderReference = (poNumber || '').trim() || draftAttachmentReference;
+
+    setAttachments((prev) =>
+      prev.map((att, i) => (i === index ? { ...att, uploading: true } : att)),
+    );
+    setMessage('');
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('business', attachmentBusiness);
+    formData.append('customerName', customerName);
+    formData.append('orderReference', orderReference);
+
+    try {
+      const res = await fetch('/api/orders/attachments/upload', {
+        method: 'POST',
+        body: formData,
+        credentials: 'include',
       });
-    };
-    reader.readAsDataURL(file);
+
+      if (!res.ok) {
+        let errorMessage = 'Failed to upload attachment';
+        try {
+          const payload = await res.json();
+          if (payload?.error) errorMessage = payload.error;
+        } catch {
+          // ignore JSON parse errors
+        }
+        throw new Error(errorMessage);
+      }
+
+      const result = await res.json().catch(() => ({}));
+
+      setAttachments((prev) =>
+        prev.map((att, i) => {
+          if (i !== index) return att;
+          const storagePath = typeof result?.storagePath === 'string' ? result.storagePath : '';
+          const url = storagePath ? `/attachments/${storagePath}` : att.url;
+          const label = att.label || (typeof result?.label === 'string' && result.label) || file.name;
+          const mimeType =
+            att.mimeType ||
+            (typeof result?.mimeType === 'string' && result.mimeType) ||
+            file.type ||
+            '';
+
+          return {
+            ...att,
+            storagePath,
+            url,
+            label,
+            mimeType,
+            uploading: false,
+          };
+        }),
+      );
+    } catch (error: any) {
+      const message = typeof error?.message === 'string' ? error.message : 'Failed to upload attachment';
+      setMessage(message);
+      setAttachments((prev) =>
+        prev.map((att, i) => (i === index ? { ...att, uploading: false } : att)),
+      );
+    }
   }
 
   async function handleSubmit(e: React.FormEvent) {
@@ -240,13 +337,26 @@ export default function NewOrderPage() {
       return;
     }
 
+    if (attachments.some((att) => att.uploading)) {
+      setMessage('Please wait for attachment uploads to finish.');
+      setLoading(false);
+      return;
+    }
+
     const cleanAttachments = attachments
-      .map((att) => ({
-        url: att.url.trim(),
-        label: att.label?.trim() || undefined,
-        mimeType: att.mimeType?.trim() || undefined,
-      }))
-      .filter((att) => att.url.length > 0);
+      .map((att) => {
+        const storagePath = att.storagePath.trim();
+        const url = att.url.trim();
+        const label = att.label.trim();
+        const mimeType = att.mimeType.trim();
+        return {
+          url: storagePath ? undefined : url || undefined,
+          storagePath: storagePath || undefined,
+          label: label || undefined,
+          mimeType: mimeType || undefined,
+        };
+      })
+      .filter((att) => Boolean(att.url?.length || att.storagePath?.length));
 
     const body = {
       customerId,
@@ -617,14 +727,42 @@ export default function NewOrderPage() {
         </Card>
 
         <Card className="border-border/60 bg-card/70 backdrop-blur">
-          <CardHeader className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+          <CardHeader className="flex flex-col gap-4 md:flex-row md:items-start md:justify-between">
             <div>
               <CardTitle>Attachments</CardTitle>
               <CardDescription>Link drawings, STEP files, or upload lightweight references.</CardDescription>
             </div>
-            <Button type="button" variant="secondary" className="rounded-full border border-primary/40 bg-primary/10 text-primary" onClick={addAttachmentRow}>
-              <PlusCircle className="mr-2 h-4 w-4" /> Add attachment
-            </Button>
+            <div className="flex flex-col gap-3 md:items-end">
+              <div className="flex flex-col gap-2 md:flex-row md:items-center md:gap-3">
+                <Label className="text-xs uppercase tracking-[0.3em] text-muted-foreground md:text-right">
+                  Storage business
+                </Label>
+                <Select value={attachmentBusiness} onValueChange={(value) => setAttachmentBusiness(value as BusinessName)}>
+                  <SelectTrigger className="w-[220px] border-border/60 bg-background/80">
+                    <SelectValue placeholder="Select a business" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {BUSINESS_OPTIONS.map((option) => (
+                      <SelectItem key={option.slug} value={option.name}>
+                        {option.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <p className="text-xs text-muted-foreground md:text-right">
+                Files upload to{' '}
+                <code className="rounded bg-muted px-1 py-0.5 text-[11px]">{attachmentPathPreview}</code>
+              </p>
+              <Button
+                type="button"
+                variant="secondary"
+                className="rounded-full border border-primary/40 bg-primary/10 text-primary"
+                onClick={addAttachmentRow}
+              >
+                <PlusCircle className="mr-2 h-4 w-4" /> Add attachment
+              </Button>
+            </div>
           </CardHeader>
           <CardContent className="grid gap-4">
             {attachments.map((att, index) => (
@@ -649,14 +787,6 @@ export default function NewOrderPage() {
                     />
                   </div>
                   <div className="grid gap-2">
-                    <Label>Link or data URL</Label>
-                    <Input
-                      value={att.url}
-                      onChange={(e) => updateAttachment(index, { url: e.target.value })}
-                      placeholder="Paste Google Drive or SharePoint link"
-                    />
-                  </div>
-                  <div className="grid gap-2">
                     <Label>Mime type</Label>
                     <Input
                       value={att.mimeType}
@@ -664,19 +794,48 @@ export default function NewOrderPage() {
                       placeholder="application/step"
                     />
                   </div>
-                  <div className="grid gap-2">
+                  <div className="grid gap-2 md:col-span-2">
+                    <Label>External link</Label>
+                    <Input
+                      value={att.url}
+                      onChange={(e) => handleAttachmentUrlChange(index, e.target.value)}
+                      placeholder="Paste Google Drive or SharePoint link"
+                      disabled={att.uploading}
+                    />
+                  </div>
+                  <div className="grid gap-2 md:col-span-2">
                     <Label>Upload file</Label>
-                    <div className="flex items-center gap-3">
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
                       <Input
                         type="file"
                         className="bg-background/80"
-                        onChange={(e) => handleAttachmentFile(index, e.target.files)}
+                        onChange={(e) => void handleAttachmentFile(index, e.target.files)}
+                        disabled={att.uploading}
                       />
-                      <Upload className="h-4 w-4 text-muted-foreground" />
+                      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                        <Upload className="h-4 w-4 text-muted-foreground" />
+                        {att.uploading ? 'Uploading…' : 'Drop a file to upload'}
+                      </div>
                     </div>
-                    <p className="text-xs text-muted-foreground">
-                      Uploading will embed a base64 data URL if you don&apos;t have a hosted link handy.
-                    </p>
+                    <div className="space-y-1 text-xs text-muted-foreground">
+                      <p>Uploads are written to the shared storage above for easy access on the shop floor.</p>
+                      {att.storagePath ? (
+                        <p className="flex flex-wrap items-center gap-1">
+                          Stored file:
+                          <code className="rounded bg-muted px-1 py-0.5 text-[11px]">{att.storagePath}</code>
+                          <a
+                            href={`/attachments/${att.storagePath}`}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="font-medium text-primary hover:underline"
+                          >
+                            Open stored copy
+                          </a>
+                        </p>
+                      ) : (
+                        <p>Add a file to copy it into shared storage.</p>
+                      )}
+                    </div>
                   </div>
                 </div>
               </div>

--- a/src/lib/zod-orders.ts
+++ b/src/lib/zod-orders.ts
@@ -38,6 +38,18 @@ export const OrderPartCreate = z.object({
   notes: z.string().trim().max(500).optional(),
 });
 
+const OrderAttachmentMetadata = z
+  .object({
+    url: z.string().trim().min(1).max(1000).optional(),
+    storagePath: z.string().trim().min(1).max(500).optional(),
+    label: z.string().trim().max(200).optional(),
+    mimeType: z.string().trim().max(200).optional(),
+  })
+  .refine((value) => Boolean(value.url?.length || value.storagePath?.length), {
+    message: 'Provide an attachment URL or uploaded file path',
+    path: ['url'],
+  });
+
 export const OrderCreate = z.object({
   orderNumber: z.string().trim().optional(),
   customerId: z.string().trim().min(1),
@@ -52,25 +64,13 @@ export const OrderCreate = z.object({
   assignedMachinistId: z.string().trim().optional(),
   parts: z.array(OrderPartCreate).min(1),
   addonIds: z.array(z.string().trim()).default([]),
-  attachments: z
-    .array(
-      z.object({
-        url: z.string().min(1),
-        label: z.string().trim().optional(),
-        mimeType: z.string().trim().optional(),
-      })
-    )
-    .default([]),
+  attachments: z.array(OrderAttachmentMetadata).default([]),
   notes: z.string().trim().max(1000).optional(),
 });
 
 export type OrderCreateInput = z.infer<typeof OrderCreate>;
 
-export const OrderAttachmentCreate = z.object({
-  url: z.string().trim().min(1),
-  label: z.string().trim().max(200).optional(),
-  mimeType: z.string().trim().max(200).optional(),
-});
+export const OrderAttachmentCreate = OrderAttachmentMetadata;
 
 export type OrderAttachmentCreateInput = z.infer<typeof OrderAttachmentCreate>;
 


### PR DESCRIPTION
## Summary
- add an authenticated API endpoint for order attachment uploads and extend the schema to store filesystem paths
- refactor order creation and detail pages to upload files to shared storage, retain returned metadata, and update attachment UX
- update attachment download routing and document migration steps for existing base64 order attachments

## Testing
- pnpm prisma generate *(fails: Prisma engines download blocked in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc37dcca08327bd954ea85b24d1b2