### PR TITLE
Add business support with prefixed quote and order numbers

### DIFF
--- a/prisma/migrations/20251015130000_add_business_fields/migration.sql
+++ b/prisma/migrations/20251015130000_add_business_fields/migration.sql
@@ -1,0 +1,58 @@
+PRAGMA foreign_keys=OFF;
+
+CREATE TABLE "new_Order" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "orderNumber" TEXT NOT NULL,
+    "business" TEXT NOT NULL DEFAULT 'STD',
+    "customerId" TEXT NOT NULL,
+    "status" TEXT NOT NULL,
+    "priority" TEXT NOT NULL,
+    "dueDate" DATETIME NOT NULL,
+    "receivedDate" DATETIME NOT NULL,
+    "modelIncluded" BOOLEAN NOT NULL DEFAULT false,
+    "materialNeeded" BOOLEAN NOT NULL DEFAULT false,
+    "materialOrdered" BOOLEAN NOT NULL DEFAULT false,
+    "vendorId" TEXT,
+    "poNumber" TEXT,
+    "assignedMachinistId" TEXT,
+    CONSTRAINT "Order_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Order_vendorId_fkey" FOREIGN KEY ("vendorId") REFERENCES "Vendor" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Order_assignedMachinistId_fkey" FOREIGN KEY ("assignedMachinistId") REFERENCES "User" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_Order" ("id", "orderNumber", "customerId", "status", "priority", "dueDate", "receivedDate", "modelIncluded", "materialNeeded", "materialOrdered", "vendorId", "poNumber", "assignedMachinistId")
+SELECT "id", "orderNumber", "customerId", "status", "priority", "dueDate", "receivedDate", "modelIncluded", "materialNeeded", "materialOrdered", "vendorId", "poNumber", "assignedMachinistId" FROM "Order";
+DROP TABLE "Order";
+ALTER TABLE "new_Order" RENAME TO "Order";
+
+CREATE TABLE "new_Quote" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "quoteNumber" TEXT NOT NULL,
+    "business" TEXT NOT NULL DEFAULT 'STD',
+    "companyName" TEXT NOT NULL,
+    "contactName" TEXT,
+    "contactEmail" TEXT,
+    "contactPhone" TEXT,
+    "customerId" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'DRAFT',
+    "materialSummary" TEXT,
+    "purchaseItems" TEXT,
+    "requirements" TEXT,
+    "notes" TEXT,
+    "multiPiece" BOOLEAN NOT NULL DEFAULT false,
+    "basePriceCents" INTEGER NOT NULL DEFAULT 0,
+    "addonsTotalCents" INTEGER NOT NULL DEFAULT 0,
+    "vendorTotalCents" INTEGER NOT NULL DEFAULT 0,
+    "totalCents" INTEGER NOT NULL DEFAULT 0,
+    "metadata" TEXT,
+    "createdById" TEXT NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Quote_customerId_fkey" FOREIGN KEY ("customerId") REFERENCES "Customer" ("id") ON DELETE SET NULL ON UPDATE CASCADE,
+    CONSTRAINT "Quote_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Quote" ("id", "quoteNumber", "companyName", "contactName", "contactEmail", "contactPhone", "customerId", "status", "materialSummary", "purchaseItems", "requirements", "notes", "multiPiece", "basePriceCents", "addonsTotalCents", "vendorTotalCents", "totalCents", "metadata", "createdById", "createdAt", "updatedAt")
+SELECT "id", "quoteNumber", "companyName", "contactName", "contactEmail", "contactPhone", "customerId", "status", "materialSummary", "purchaseItems", "requirements", "notes", "multiPiece", "basePriceCents", "addonsTotalCents", "vendorTotalCents", "totalCents", "metadata", "createdById", "createdAt", "updatedAt" FROM "Quote";
+DROP TABLE "Quote";
+ALTER TABLE "new_Quote" RENAME TO "Quote";
+
+PRAGMA foreign_keys=ON;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,7 +7,11 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-// NOTE: No enums on SQLite. Use strings instead.
+enum Business {
+  STD
+  CRM
+  PC
+}
 
 model User {
   id               String   @id @default(cuid())
@@ -68,6 +72,7 @@ model Vendor {
 model Order {
   id               String   @id @default(cuid())
   orderNumber      String
+  business         Business @default(STD)
   customerId       String
   customer         Customer @relation(fields: [customerId], references: [id])
   status           String
@@ -184,6 +189,7 @@ model Addon {
 model Quote {
   id               String   @id @default(cuid())
   quoteNumber      String
+  business         Business @default(STD)
   companyName      String
   contactName      String?
   contactEmail     String?

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -95,10 +95,11 @@ async function main() {
   const mats = await prisma.material.findMany();
   const checklistAddons = addonRecords.slice(0, 5);
 
-  async function seedOrder(idx, customerId, assigned) {
+  async function seedOrder(idx, customerId, assigned, business) {
     const ord = await prisma.order.create({
       data: {
-        orderNumber: `SO-${1000 + idx}`,
+        orderNumber: `${business}-${1000 + idx}`,
+        business,
         customerId,
         modelIncluded: idx % 2 === 0,
         receivedDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * (7 - idx)),
@@ -140,14 +141,14 @@ async function main() {
     });
   }
 
-  await seedOrder(1, acme.id, mach1.id);
-  await seedOrder(2, acme.id, mach2.id);
-  await seedOrder(3, wayne.id, mach1.id);
-  await seedOrder(4, wayne.id, mach2.id);
-  await seedOrder(5, acme.id, null);
-  await seedOrder(6, acme.id, null);
-  await seedOrder(7, wayne.id, mach1.id);
-  await seedOrder(8, wayne.id, mach2.id);
+  await seedOrder(1, acme.id, mach1.id, 'STD');
+  await seedOrder(2, acme.id, mach2.id, 'STD');
+  await seedOrder(3, wayne.id, mach1.id, 'CRM');
+  await seedOrder(4, wayne.id, mach2.id, 'CRM');
+  await seedOrder(5, acme.id, null, 'STD');
+  await seedOrder(6, acme.id, null, 'STD');
+  await seedOrder(7, wayne.id, mach1.id, 'PC');
+  await seedOrder(8, wayne.id, mach2.id, 'PC');
 }
 
 main().catch(e => {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -99,10 +99,17 @@ async function main() {
   const mats = await prisma.material.findMany();
   const checklistAddons = addonRecords.slice(0, 5);
 
-  async function seedOrder(idx: number, customerId: string, assigned?: string | null) {
+  async function seedOrder(
+    idx: number,
+    customerId: string,
+    assigned: string | null = null,
+    business: 'STD' | 'CRM' | 'PC',
+  ) {
+    const orderNumber = `${business}-${1000 + idx}`;
     const ord = await prisma.order.create({
       data: {
-        orderNumber: String(1000 + idx),
+        orderNumber,
+        business,
         customerId,
         modelIncluded: idx % 2 === 0,
         receivedDate: new Date(Date.now() - 1000 * 60 * 60 * 24 * (7 - idx)),
@@ -144,14 +151,14 @@ async function main() {
     });
   }
 
-  await seedOrder(1, acme.id, mach1.id);
-  await seedOrder(2, acme.id, mach2.id);
-  await seedOrder(3, wayne.id, mach1.id);
-  await seedOrder(4, wayne.id, mach2.id);
-  await seedOrder(5, acme.id, null);
-  await seedOrder(6, acme.id, null);
-  await seedOrder(7, wayne.id, mach1.id);
-  await seedOrder(8, wayne.id, mach2.id);
+  await seedOrder(1, acme.id, mach1.id, 'STD');
+  await seedOrder(2, acme.id, mach2.id, 'STD');
+  await seedOrder(3, wayne.id, mach1.id, 'CRM');
+  await seedOrder(4, wayne.id, mach2.id, 'CRM');
+  await seedOrder(5, acme.id, null, 'STD');
+  await seedOrder(6, acme.id, null, 'STD');
+  await seedOrder(7, wayne.id, mach1.id, 'PC');
+  await seedOrder(8, wayne.id, mach2.id, 'PC');
 
   const sawAddon = addonRecords.find((a) => a.name === 'Saw');
   const weldAddon = addonRecords.find((a) => a.name === 'Weld');
@@ -171,7 +178,8 @@ async function main() {
       where: { quoteNumber: 'Q-1001' },
       update: {},
       create: {
-        quoteNumber: 'Q-1001',
+        quoteNumber: 'STD-20231015-0001',
+        business: 'STD',
         companyName: 'ACME Corp',
         contactName: 'Jane Engineer',
         contactEmail: 'jane.engineer@acme.example',
@@ -256,7 +264,7 @@ async function main() {
         attachments: {
           create: [
             {
-              url: 'https://example.com/quotes/Q-1001/customer-print.pdf',
+              url: 'https://example.com/quotes/STD-20231015-0001/customer-print.pdf',
               label: 'Customer print',
             },
           ],

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -2,6 +2,7 @@ import { notFound, redirect } from 'next/navigation';
 import { getServerSession } from 'next-auth';
 import Link from 'next/link';
 
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/Button';
 import {
   Card,
@@ -13,6 +14,7 @@ import {
 import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/lib/auth';
 import { canAccessAdmin } from '@/lib/rbac';
+import { BUSINESS_OPTIONS } from '@/lib/businesses';
 
 const STATUS_LABELS: Record<string, string> = {
   DRAFT: 'Draft',
@@ -50,6 +52,8 @@ export default async function QuoteDetailPage({ params }: { params: { id: string
     notFound();
   }
 
+  const businessOption = BUSINESS_OPTIONS.find((option) => option.code === quote.business);
+
   const statusLabel = STATUS_LABELS[quote.status] ?? quote.status;
   const addonTotal = quote.addonSelections.reduce((sum, selection) => sum + selection.totalCents, 0);
   const vendorTotal = quote.vendorItems.reduce((sum, item) => sum + item.finalPriceCents, 0);
@@ -58,7 +62,15 @@ export default async function QuoteDetailPage({ params }: { params: { id: string
     <div className="p-4 text-neutral-100 space-y-6">
       <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
         <div>
-          <h1 className="text-2xl font-semibold">Quote {quote.quoteNumber}</h1>
+          <div className="flex flex-wrap items-center gap-2">
+            <h1 className="text-2xl font-semibold">Quote {quote.quoteNumber}</h1>
+            <Badge variant="outline" className="font-mono text-xs uppercase">
+              {businessOption?.prefix ?? quote.business}
+            </Badge>
+            <span className="text-sm text-muted-foreground">
+              {businessOption?.name ?? 'Unknown business'}
+            </span>
+          </div>
           <p className="text-sm text-muted-foreground">
             Prepared for {quote.companyName}
             {quote.contactName ? ` — attention: ${quote.contactName}` : ''}
@@ -93,6 +105,10 @@ export default async function QuoteDetailPage({ params }: { params: { id: string
             <div className="flex justify-between">
               <span className="text-muted-foreground">Status</span>
               <span className="font-medium">{statusLabel}</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-muted-foreground">Business</span>
+              <span className="font-medium">{businessOption?.name ?? quote.business}</span>
             </div>
             {quote.customer?.name && (
               <div className="flex justify-between">

--- a/src/app/admin/quotes/client.tsx
+++ b/src/app/admin/quotes/client.tsx
@@ -6,13 +6,16 @@ import React, { useMemo, useState } from 'react';
 
 import Table from '@/components/Admin/Table';
 import { useToast } from '@/components/ui/Toast';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { BUSINESS_OPTIONS } from '@/lib/businesses';
 import { fetchJson } from '@/lib/fetchJson';
 
 interface QuoteItem {
   id: string;
   quoteNumber: string;
+  business: string;
   companyName: string;
   contactName?: string | null;
   status: string;
@@ -55,6 +58,24 @@ export default function Client({ initial }: ClientProps) {
             {row.quoteNumber}
           </Link>
         ),
+      },
+      {
+        key: 'business',
+        header: 'Business',
+        render: (value: string) => {
+          const option = BUSINESS_OPTIONS.find((item) => item.code === value);
+          if (!option) {
+            return <Badge variant="outline">{value}</Badge>;
+          }
+          return (
+            <div className="flex flex-col gap-1">
+              <Badge variant="outline" className="w-fit font-mono text-xs">
+                {option.prefix}
+              </Badge>
+              <span className="text-xs text-muted-foreground">{option.name}</span>
+            </div>
+          );
+        },
       },
       {
         key: 'companyName',

--- a/src/app/api/admin/quotes/[id]/route.ts
+++ b/src/app/api/admin/quotes/[id]/route.ts
@@ -87,6 +87,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     where: { id: params.id },
     data: {
       quoteNumber: prepared.quoteNumber,
+      business: parsed.data.business,
       companyName: parsed.data.companyName,
       contactName: parsed.data.contactName ?? null,
       contactEmail: parsed.data.contactEmail ?? null,

--- a/src/app/api/admin/quotes/route.ts
+++ b/src/app/api/admin/quotes/route.ts
@@ -106,6 +106,7 @@ export async function POST(req: NextRequest) {
   const created = await prisma.quote.create({
     data: {
       quoteNumber: prepared.quoteNumber,
+      business: data.business,
       companyName: data.companyName,
       contactName: data.contactName ?? null,
       contactEmail: data.contactEmail ?? null,

--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -32,6 +32,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { BUSINESS_OPTIONS } from '@/lib/businesses';
 
 const SORT_KEYS = ['dueDate', 'priority', 'status'] as const;
 const PRIORITY_FILTERS = ['all', 'HOT', 'RUSH', 'NORMAL', 'LOW'] as const;
@@ -323,6 +324,7 @@ export default function OrdersPage() {
               <TableHeader>
                 <TableRow className="border-border/60">
                   <TableHead className="w-[140px]">Order</TableHead>
+                  <TableHead>Business</TableHead>
                   <TableHead>Customer</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead>Due</TableHead>
@@ -338,6 +340,22 @@ export default function OrdersPage() {
                       <Link href={`/orders/${order.id}`} className="hover:underline">
                         #{order.orderNumber}
                       </Link>
+                    </TableCell>
+                    <TableCell>
+                      {(() => {
+                        const option = BUSINESS_OPTIONS.find((item) => item.code === order.business);
+                        if (!option) {
+                          return <Badge variant="outline">{order.business ?? 'N/A'}</Badge>;
+                        }
+                        return (
+                          <div className="flex flex-col gap-1">
+                            <Badge variant="outline" className="w-fit font-mono text-xs uppercase">
+                              {option.prefix}
+                            </Badge>
+                            <span className="text-xs text-muted-foreground">{option.name}</span>
+                          </div>
+                        );
+                      })()}
                     </TableCell>
                     <TableCell className="text-sm text-muted-foreground">
                       {order.customer?.name ?? 'Unknown customer'}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -3,7 +3,7 @@ import Credentials from 'next-auth/providers/credentials';
 import { prisma } from './prisma';
 import { compare } from 'bcryptjs';
 
-export const authOptions: NextAuthOptions = {
+export const authOptions: NextAuthOptions & { trustHost?: boolean } = {
   trustHost: true,
   session: { strategy: 'jwt' },
   pages: { signIn: '/auth/signin' },

--- a/src/lib/businesses.ts
+++ b/src/lib/businesses.ts
@@ -1,14 +1,22 @@
-export const BUSINESS_NAMES = [
-  'Sterling Tool and Die',
-  'C and R Machining',
-  'Powder Coating',
+export const BUSINESS_CODE_VALUES = ['STD', 'CRM', 'PC'] as const;
+
+const BUSINESS_CONFIG = [
+  { code: BUSINESS_CODE_VALUES[0], name: 'Sterling Tool and Die', prefix: 'STD' },
+  { code: BUSINESS_CODE_VALUES[1], name: 'C and R Machining', prefix: 'CRM' },
+  { code: BUSINESS_CODE_VALUES[2], name: 'Powder Coating', prefix: 'PC' },
 ] as const;
 
-export type BusinessName = (typeof BUSINESS_NAMES)[number];
+export type BusinessCode = (typeof BUSINESS_CONFIG)[number]['code'];
+export type BusinessName = (typeof BUSINESS_CONFIG)[number]['name'];
+
+export const BUSINESS_CODES = BUSINESS_CODE_VALUES;
+export const BUSINESS_NAMES = BUSINESS_CONFIG.map((item) => item.name) as readonly BusinessName[];
 
 export interface BusinessOption {
+  code: BusinessCode;
   name: BusinessName;
   slug: string;
+  prefix: string;
 }
 
 export function slugifyName(value: string | null | undefined, fallback = 'item'): string {
@@ -24,7 +32,66 @@ export function slugifyName(value: string | null | undefined, fallback = 'item')
   return slug || fallback;
 }
 
-export const BUSINESS_OPTIONS: readonly BusinessOption[] = BUSINESS_NAMES.map((name) => ({
-  name,
-  slug: slugifyName(name, 'business'),
+export const BUSINESS_OPTIONS: readonly BusinessOption[] = BUSINESS_CONFIG.map((item) => ({
+  code: item.code,
+  name: item.name,
+  slug: slugifyName(item.name, 'business'),
+  prefix: item.prefix,
 }));
+
+export const BUSINESS_PREFIX_BY_CODE: Record<BusinessCode, string> = BUSINESS_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.code] = option.prefix;
+    return acc;
+  },
+  {} as Record<BusinessCode, string>,
+);
+
+export const BUSINESS_NAME_BY_CODE: Record<BusinessCode, BusinessName> = BUSINESS_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.code] = option.name;
+    return acc;
+  },
+  {} as Record<BusinessCode, BusinessName>,
+);
+
+export const BUSINESS_CODE_BY_NAME: Record<BusinessName, BusinessCode> = BUSINESS_OPTIONS.reduce(
+  (acc, option) => {
+    acc[option.name] = option.code;
+    return acc;
+  },
+  {} as Record<BusinessName, BusinessCode>,
+);
+
+export function getBusinessOptionByCode(code: string | null | undefined): BusinessOption | undefined {
+  if (!code) return undefined;
+  return BUSINESS_OPTIONS.find((option) => option.code === code) ?? undefined;
+}
+
+export function getBusinessOptionByName(name: string | null | undefined): BusinessOption | undefined {
+  if (!name) return undefined;
+  return BUSINESS_OPTIONS.find((option) => option.name === name) ?? undefined;
+}
+
+export function businessNameFromCode(
+  code: string | null | undefined,
+  fallback: BusinessName = BUSINESS_OPTIONS[0]?.name ?? 'Sterling Tool and Die',
+): BusinessName {
+  const option = getBusinessOptionByCode(code);
+  return option?.name ?? fallback;
+}
+
+export function businessCodeFromName(
+  name: string | null | undefined,
+  fallback?: BusinessCode,
+): BusinessCode | undefined {
+  if (!name) return fallback;
+  const option = getBusinessOptionByName(name as BusinessName);
+  return option?.code ?? fallback;
+}
+
+export function businessPrefixFromCode(code: string | null | undefined): string | undefined {
+  if (!code) return undefined;
+  const option = getBusinessOptionByCode(code);
+  return option?.prefix;
+}

--- a/src/lib/quotes.server.ts
+++ b/src/lib/quotes.server.ts
@@ -1,11 +1,17 @@
 import { prisma } from '@/lib/prisma';
+import { BUSINESS_PREFIX_BY_CODE, type BusinessCode } from './businesses';
 import { QuoteCreateInput } from './zod-quotes';
 
-export async function generateQuoteNumber() {
+function prefixForBusiness(business: BusinessCode): string {
+  return BUSINESS_PREFIX_BY_CODE[business] ?? business;
+}
+
+export async function generateQuoteNumber(business: BusinessCode) {
+  const prefix = prefixForBusiness(business);
   const now = new Date();
   const stamp = `${now.getFullYear()}${String(now.getMonth() + 1).padStart(2, '0')}${String(now.getDate()).padStart(2, '0')}`;
   for (let attempt = 0; attempt < 5; attempt += 1) {
-    const candidate = `Q-${stamp}-${Math.floor(Math.random() * 10000)
+    const candidate = `${prefix}-${stamp}-${Math.floor(Math.random() * 10000)
       .toString()
       .padStart(4, '0')}`;
     const existing = await prisma.quote.findUnique({ where: { quoteNumber: candidate } });
@@ -13,7 +19,7 @@ export async function generateQuoteNumber() {
       return candidate;
     }
   }
-  return `Q-${stamp}-${Date.now()}`;
+  return `${prefix}-${stamp}-${Date.now()}`;
 }
 
 export interface PreparedQuoteComponents {
@@ -60,6 +66,8 @@ export async function prepareQuoteComponents(
   input: QuoteCreateInput,
   options?: { existingQuoteNumber?: string }
 ): Promise<PreparedQuoteComponents> {
+  const business = input.business as BusinessCode;
+  const prefix = prefixForBusiness(business);
   const parts = input.parts ?? [];
   const vendorItemsInput = input.vendorItems ?? [];
   const addonSelectionsInput = input.addonSelections ?? [];
@@ -125,9 +133,22 @@ export async function prepareQuoteComponents(
   const basePriceCents = input.basePriceCents ?? 0;
   const totalCents = basePriceCents + vendorTotalCents + addonsTotalCents;
 
-  const quoteNumber = input.quoteNumber && input.quoteNumber.trim().length > 0
-    ? input.quoteNumber.trim()
-    : options?.existingQuoteNumber ?? (await generateQuoteNumber());
+  const providedQuoteNumber = input.quoteNumber?.trim();
+  let quoteNumber: string;
+  if (providedQuoteNumber && providedQuoteNumber.length > 0) {
+    if (!providedQuoteNumber.startsWith(`${prefix}-`)) {
+      throw new Error(`Quote numbers for ${prefix} must start with ${prefix}-`);
+    }
+    quoteNumber = providedQuoteNumber;
+  } else if (options?.existingQuoteNumber && options.existingQuoteNumber.length > 0) {
+    if (options.existingQuoteNumber.startsWith(`${prefix}-`)) {
+      quoteNumber = options.existingQuoteNumber;
+    } else {
+      quoteNumber = await generateQuoteNumber(business);
+    }
+  } else {
+    quoteNumber = await generateQuoteNumber(business);
+  }
 
   const multiPiece =
     typeof input.multiPiece === 'boolean'

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -4,8 +4,17 @@ import { mkdir, writeFile } from 'node:fs/promises';
 
 import { slugifyName, type BusinessName } from './businesses';
 
-export { BUSINESS_NAMES, BUSINESS_OPTIONS, slugifyName } from './businesses';
-export type { BusinessName, BusinessOption } from './businesses';
+export {
+  BUSINESS_NAMES,
+  BUSINESS_OPTIONS,
+  BUSINESS_CODES,
+  BUSINESS_PREFIX_BY_CODE,
+  businessCodeFromName,
+  businessNameFromCode,
+  businessPrefixFromCode,
+  slugifyName,
+} from './businesses';
+export type { BusinessName, BusinessOption, BusinessCode } from './businesses';
 
 export const ATTACHMENTS_ROOT = process.env.ATTACHMENTS_DIR ?? 'storage';
 

--- a/src/lib/zod-orders.ts
+++ b/src/lib/zod-orders.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { BUSINESS_CODES } from '@/lib/businesses';
+
 /** Enums mirrored from Prisma */
 export const StatusEnum = z.enum([
   'RECEIVED',
@@ -52,6 +54,7 @@ const OrderAttachmentMetadata = z
 
 export const OrderCreate = z.object({
   orderNumber: z.string().trim().optional(),
+  business: z.enum(BUSINESS_CODES),
   customerId: z.string().trim().min(1),
   modelIncluded: z.boolean().default(false),
   receivedDate: z.string().min(1),

--- a/src/lib/zod-quotes.ts
+++ b/src/lib/zod-quotes.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { BUSINESS_CODES } from '@/lib/businesses';
+
 export const QuotePartInput = z.object({
   name: z.string().trim().min(1).max(200),
   description: z.string().trim().max(2000).optional(),
@@ -38,6 +40,7 @@ export const QuoteAttachmentInput = z
   });
 
 export const QuoteCreate = z.object({
+  business: z.enum(BUSINESS_CODES),
   quoteNumber: z.string().trim().max(50).optional(),
   companyName: z.string().trim().min(1).max(200),
   contactName: z.string().trim().max(200).optional(),
@@ -57,7 +60,7 @@ export const QuoteCreate = z.object({
   attachments: z.array(QuoteAttachmentInput).default([]),
 });
 
-export const QuoteUpdate = QuoteCreate.partial();
+export const QuoteUpdate = QuoteCreate;
 
 export type QuoteCreateInput = z.infer<typeof QuoteCreate>;
 export type QuoteUpdateInput = z.infer<typeof QuoteUpdate>;


### PR DESCRIPTION
## Summary
- add a Business enum/column in Prisma along with migration and seeded prefixes
- require business selection for quotes and orders, storing and showing the value in admin and order UIs
- prefix quote/order numbers by business and validate provided numbers use the expected prefix

## Testing
- `npx prisma generate` *(fails: Prisma engine download blocked by 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dbc9f23b1083278fc4bbb161268d06