### PR TITLE
Implement quote-to-order conversion flow

### DIFF
--- a/docs/quote-order-conversion.md
+++ b/docs/quote-order-conversion.md
@@ -1,0 +1,14 @@
+# Quote to order conversion workflow
+
+Quotes can now be promoted into production orders once purchasing approval or a customer PO has been recorded. The admin quote detail page includes a **PO / Approval received** toggle that prompts for an approval upload. The same control appears on the quote list so coordinators can flag approvals without leaving the table.
+
+When the approval is marked as received we persist a dedicated quote attachment and store the association in quote metadata. The **Convert to order** action becomes available once approval is on file and the quote is linked to a customer. Converting will:
+
+- Generate the next order number for the originating business code.
+- Copy quote parts, add-on selections, and attachments into the new order.
+- Duplicate every uploaded attachment into the order's storage directory so the original quote retains its files. Remote attachments are copied as links.
+- Stamp the quote metadata with the order id/number to prevent duplicate conversions.
+
+### Attachment storage policy
+
+Quote attachments are **copied** when an order is created. The original quote attachment remains in place to preserve the quoting record; no automated cleanup currently runs on legacy quote files. Operations can safely remove stale quote files manually if storage pressure becomes a concern, but only after confirming the corresponding order has its own copy. Future cleanup tooling should look for quotes with `metadata.conversion.orderId` set and a matching order attachment before deleting quote artifacts.

--- a/src/app/admin/quotes/QuoteWorkflowControls.tsx
+++ b/src/app/admin/quotes/QuoteWorkflowControls.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import React from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+
+import { Button } from '@/components/ui/Button';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/label';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { useToast } from '@/components/ui/Toast';
+import { fetchJson } from '@/lib/fetchJson';
+import type { QuoteApprovalMetadata, QuoteConversionMetadata, QuoteMetadata } from '@/lib/quote-metadata';
+import type { BusinessName } from '@/lib/businesses';
+
+interface QuoteWorkflowControlsProps {
+  quoteId: string;
+  quoteNumber: string;
+  businessName: BusinessName;
+  companyName: string;
+  customerName: string;
+  customerId?: string | null;
+  approval: QuoteApprovalMetadata;
+  conversion: QuoteConversionMetadata;
+  layout?: 'detail' | 'table';
+  onMetadataUpdate?: (metadata: QuoteMetadata) => void;
+  onConverted?: (args: { orderId: string; orderNumber: string; metadata: QuoteMetadata }) => void;
+}
+
+const CHECKBOX_LABEL = 'PO / Approval received';
+
+export default function QuoteWorkflowControls({
+  quoteId,
+  quoteNumber,
+  businessName,
+  companyName,
+  customerName,
+  customerId,
+  approval,
+  conversion,
+  layout = 'detail',
+  onMetadataUpdate,
+  onConverted,
+}: QuoteWorkflowControlsProps) {
+  const router = useRouter();
+  const toast = useToast();
+
+  const [approvalState, setApprovalState] = React.useState<QuoteApprovalMetadata>(approval);
+  const [conversionState, setConversionState] = React.useState<QuoteConversionMetadata>(conversion);
+  const [dialogOpen, setDialogOpen] = React.useState(false);
+  const [selectedFile, setSelectedFile] = React.useState<File | null>(null);
+  const [uploadError, setUploadError] = React.useState<string | null>(null);
+  const [savingApproval, setSavingApproval] = React.useState(false);
+  const [converting, setConverting] = React.useState(false);
+  const [uploading, setUploading] = React.useState(false);
+
+  React.useEffect(() => {
+    setApprovalState(approval);
+  }, [approval]);
+
+  React.useEffect(() => {
+    setConversionState(conversion);
+  }, [conversion]);
+
+  const attachmentHref = React.useMemo(() => {
+    if (approvalState?.attachmentUrl) {
+      return approvalState.attachmentUrl;
+    }
+    if (approvalState?.attachmentStoragePath) {
+      return `/attachments/${approvalState.attachmentStoragePath}`;
+    }
+    return null;
+  }, [approvalState]);
+
+  const readyForConversion =
+    Boolean(approvalState?.received) && Boolean(customerId) && !conversionState?.orderId;
+
+  const alreadyConverted = Boolean(conversionState?.orderId);
+
+  function closeDialog() {
+    setDialogOpen(false);
+    setSelectedFile(null);
+    setUploadError(null);
+  }
+
+  async function markApproval(received: boolean, attachment?: any) {
+    setSavingApproval(true);
+    try {
+      const response = await fetchJson<{ approval: QuoteApprovalMetadata; metadata: QuoteMetadata }>(
+        `/api/admin/quotes/${quoteId}/approval`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ received, attachment }),
+        },
+      );
+
+      setApprovalState(response.approval);
+      onMetadataUpdate?.(response.metadata);
+      if (layout === 'detail') {
+        router.refresh();
+      }
+      toast.push(received ? 'Approval file captured.' : 'Approval status updated.', 'success');
+    } catch (error: any) {
+      const message = error?.body?.error || error.message || 'Failed to update approval status';
+      toast.push(message, 'error');
+    } finally {
+      setSavingApproval(false);
+    }
+  }
+
+  async function handleApprovalToggle(next: boolean | 'indeterminate') {
+    const checked = Boolean(next);
+    if (checked) {
+      setDialogOpen(true);
+      return;
+    }
+
+    if (approvalState?.received) {
+      await markApproval(false);
+    }
+  }
+
+  async function handleUploadSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!selectedFile) {
+      setUploadError('Select an approval or PO file to continue.');
+      return;
+    }
+
+    setUploading(true);
+    setUploadError(null);
+
+    try {
+      const formData = new FormData();
+      formData.append('file', selectedFile);
+      formData.append('business', businessName);
+      formData.append('customerName', customerName || companyName);
+      formData.append('quoteNumber', quoteNumber);
+
+      const uploadResponse = await fetch(`/api/admin/quotes/upload`, {
+        method: 'POST',
+        body: formData,
+      });
+
+      if (!uploadResponse.ok) {
+        const body = await uploadResponse.json().catch(() => ({}));
+        const message = body?.error || 'Failed to upload approval file';
+        throw new Error(message);
+      }
+
+      const uploaded = await uploadResponse.json();
+      await markApproval(true, uploaded);
+      closeDialog();
+    } catch (error: any) {
+      setUploadError(error?.message || 'Failed to save approval file');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  async function handleConvert() {
+    setConverting(true);
+    try {
+      const response = await fetchJson<{ orderId: string; orderNumber: string; metadata: QuoteMetadata }>(
+        `/api/admin/quotes/${quoteId}/convert`,
+        { method: 'POST' },
+      );
+
+      setConversionState(response.metadata.conversion ?? conversionState);
+      setApprovalState(response.metadata.approval ?? approvalState);
+      onMetadataUpdate?.(response.metadata);
+      onConverted?.(response);
+
+      toast.push(`Order ${response.orderNumber} created from quote ${quoteNumber}.`, 'success');
+
+      if (layout === 'detail') {
+        router.refresh();
+        router.push(`/orders/${response.orderId}`);
+      }
+    } catch (error: any) {
+      const message = error?.body?.error || error.message || 'Conversion failed';
+      toast.push(message, 'error');
+    } finally {
+      setConverting(false);
+    }
+  }
+
+  const approvalControls = (
+    <div className="flex items-center gap-2">
+      <Checkbox
+        id={`approval-toggle-${quoteId}`}
+        checked={Boolean(approvalState?.received)}
+        onCheckedChange={handleApprovalToggle}
+        disabled={savingApproval || converting}
+      />
+      <Label
+        htmlFor={`approval-toggle-${quoteId}`}
+        className={layout === 'table' ? 'text-xs font-medium' : 'text-sm font-medium'}
+      >
+        {CHECKBOX_LABEL}
+      </Label>
+      {approvalState?.received && attachmentHref && (
+        <Button asChild variant="link" size={layout === 'table' ? 'sm' : 'default'} className="px-0">
+          <Link href={attachmentHref} target="_blank" rel="noopener noreferrer">
+            View file
+          </Link>
+        </Button>
+      )}
+    </div>
+  );
+
+  return (
+    <div className={layout === 'table' ? 'flex flex-col gap-2 text-xs' : 'space-y-3'}>
+      {approvalControls}
+
+      <Dialog open={dialogOpen} onOpenChange={(open) => (open ? setDialogOpen(true) : closeDialog())}>
+        <DialogContent className="sm:max-w-md">
+          <form onSubmit={handleUploadSubmit} className="space-y-4">
+            <DialogHeader>
+              <DialogTitle>Upload approval or PO</DialogTitle>
+              <DialogDescription>
+                Attach the signed approval or purchase order to mark this quote ready for conversion.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="grid gap-2">
+              <Label htmlFor={`approval-file-${quoteId}`} className="text-sm">
+                Approval file
+              </Label>
+              <Input
+                id={`approval-file-${quoteId}`}
+                type="file"
+                required
+                onChange={(event) => {
+                  setUploadError(null);
+                  setSelectedFile(event.target.files?.[0] ?? null);
+                }}
+              />
+            </div>
+            {uploadError && (
+              <p className="text-sm text-destructive">{uploadError}</p>
+            )}
+            <DialogFooter className="flex items-center justify-end gap-2">
+              <Button type="button" variant="ghost" onClick={closeDialog} disabled={uploading}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={uploading}>
+                {uploading ? 'Uploading…' : 'Save approval'}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+
+      <div className={layout === 'table' ? 'flex flex-col gap-2' : 'flex flex-col gap-2'}>
+        {alreadyConverted ? (
+          <p className={layout === 'table' ? 'text-xs text-muted-foreground' : 'text-sm text-muted-foreground'}>
+            Converted to{' '}
+            <Link href={`/orders/${conversionState.orderId}`} className="text-primary underline">
+              {conversionState.orderNumber ?? 'View order'}
+            </Link>
+            .
+          </p>
+        ) : (
+          <Button
+            onClick={handleConvert}
+            disabled={!readyForConversion || savingApproval || converting}
+            variant={layout === 'table' ? 'outline' : 'default'}
+            size={layout === 'table' ? 'sm' : 'default'}
+            title={
+              readyForConversion
+                ? 'Convert this quote into a work order'
+                : !approvalState?.received
+                ? 'Upload approval before converting'
+                : 'Link this quote to a customer before converting'
+            }
+          >
+            {converting ? 'Converting…' : 'Convert to order'}
+          </Button>
+        )}
+        {!alreadyConverted && !approvalState?.received && (
+          <p className={layout === 'table' ? 'text-[11px] text-muted-foreground' : 'text-xs text-muted-foreground'}>
+            Upload a PO or approval to enable conversion.
+          </p>
+        )}
+        {!alreadyConverted && approvalState?.received && !customerId && (
+          <p className={layout === 'table' ? 'text-[11px] text-destructive' : 'text-xs text-destructive'}>
+            Assign a customer record before converting.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/app/admin/quotes/page.tsx
+++ b/src/app/admin/quotes/page.tsx
@@ -7,6 +7,7 @@ import { prisma } from '@/lib/prisma';
 import { authOptions } from '@/lib/auth';
 import { canAccessAdmin } from '@/lib/rbac';
 import Client from './client';
+import { mergeQuoteMetadata, parseQuoteMetadata } from '@/lib/quote-metadata';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,7 +17,7 @@ export default async function Page() {
     redirect('/');
   }
 
-  const items = await prisma.quote.findMany({
+  const rawItems = await prisma.quote.findMany({
     orderBy: { createdAt: 'desc' },
     take: 20,
     include: {
@@ -24,6 +25,11 @@ export default async function Page() {
       createdBy: { select: { id: true, name: true, email: true } },
     },
   });
+
+  const items = rawItems.map((item) => ({
+    ...item,
+    metadata: mergeQuoteMetadata(parseQuoteMetadata(item.metadata)),
+  }));
 
   const initial = { items, nextCursor: null };
 

--- a/src/app/api/admin/quotes/[id]/approval/route.ts
+++ b/src/app/api/admin/quotes/[id]/approval/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+import { z } from 'zod';
+
+import { authOptions } from '@/lib/auth';
+import {
+  DEFAULT_QUOTE_METADATA,
+  mergeQuoteMetadata,
+  parseQuoteMetadata,
+  stringifyQuoteMetadata,
+  type QuoteApprovalMetadata,
+} from '@/lib/quote-metadata';
+import { canAccessAdmin } from '@/lib/rbac';
+import { prisma } from '@/lib/prisma';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  return { session };
+}
+
+const AttachmentSchema = z
+  .object({
+    url: z.string().trim().max(500).optional(),
+    storagePath: z.string().trim().max(500).optional(),
+    label: z.string().trim().max(200).optional(),
+    mimeType: z.string().trim().max(200).optional().nullable(),
+  })
+  .refine((value) => Boolean(value.url?.length || value.storagePath?.length), {
+    message: 'Attachment requires a URL or storage path',
+    path: ['storagePath'],
+  });
+
+const BodySchema = z.object({
+  received: z.boolean(),
+  attachment: AttachmentSchema.optional(),
+});
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const body = await req.json().catch(() => null);
+  const parsed = BodySchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const { received, attachment } = parsed.data;
+
+  return prisma.$transaction(async (tx) => {
+    const quote = await tx.quote.findUnique({
+      where: { id: params.id },
+      include: { attachments: true },
+    });
+
+    if (!quote) {
+      return new NextResponse('Not found', { status: 404 });
+    }
+
+    const metadata = mergeQuoteMetadata(parseQuoteMetadata(quote.metadata) ?? DEFAULT_QUOTE_METADATA);
+
+    if (received && !attachment && !metadata.approval?.attachmentId) {
+      return NextResponse.json(
+        { error: 'An approval document must be uploaded before marking as received.' },
+        { status: 400 },
+      );
+    }
+
+    let createdAttachmentId: string | null = null;
+    let createdAttachmentLabel: string | null = null;
+    let createdAttachmentStoragePath: string | null = null;
+    let createdAttachmentUrl: string | null = null;
+    let uploadedAt: string | null = null;
+
+    if (received && attachment) {
+      const created = await tx.quoteAttachment.create({
+        data: {
+          quoteId: quote.id,
+          url: attachment.url ?? null,
+          storagePath: attachment.storagePath ?? null,
+          label: attachment.label ?? null,
+          mimeType: attachment.mimeType ?? null,
+        },
+      });
+      createdAttachmentId = created.id;
+      createdAttachmentLabel = created.label ?? attachment.label ?? null;
+      createdAttachmentStoragePath = created.storagePath ?? attachment.storagePath ?? null;
+      createdAttachmentUrl = created.url ?? attachment.url ?? null;
+      uploadedAt = created.createdAt.toISOString();
+    }
+
+    const approval: QuoteApprovalMetadata = {
+      ...metadata.approval,
+      received,
+      attachmentId:
+        received && (createdAttachmentId || metadata.approval?.attachmentId)
+          ? createdAttachmentId ?? metadata.approval?.attachmentId ?? null
+          : null,
+      attachmentLabel:
+        received && (createdAttachmentLabel || metadata.approval?.attachmentLabel)
+          ? createdAttachmentLabel ?? metadata.approval?.attachmentLabel ?? null
+          : null,
+      attachmentStoragePath:
+        received && (createdAttachmentStoragePath || metadata.approval?.attachmentStoragePath)
+          ? createdAttachmentStoragePath ?? metadata.approval?.attachmentStoragePath ?? null
+          : null,
+      attachmentUrl:
+        received && (createdAttachmentUrl || metadata.approval?.attachmentUrl)
+          ? createdAttachmentUrl ?? metadata.approval?.attachmentUrl ?? null
+          : null,
+      uploadedAt: received ? uploadedAt ?? metadata.approval?.uploadedAt ?? null : null,
+    };
+
+    const updatedMetadata = mergeQuoteMetadata({
+      ...metadata,
+      approval,
+    });
+
+    const updatedQuote = await tx.quote.update({
+      where: { id: quote.id },
+      data: { metadata: stringifyQuoteMetadata(updatedMetadata) },
+      include: { attachments: true },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      approval,
+      metadata: mergeQuoteMetadata(parseQuoteMetadata(updatedQuote.metadata) ?? DEFAULT_QUOTE_METADATA),
+      attachments: updatedQuote.attachments,
+    });
+  });
+}

--- a/src/app/api/admin/quotes/[id]/convert/route.ts
+++ b/src/app/api/admin/quotes/[id]/convert/route.ts
@@ -1,0 +1,296 @@
+import path from 'node:path';
+import { readFile } from 'node:fs/promises';
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getServerSession } from 'next-auth';
+
+import { authOptions } from '@/lib/auth';
+import {
+  DEFAULT_QUOTE_METADATA,
+  mergeQuoteMetadata,
+  parseQuoteMetadata,
+  stringifyQuoteMetadata,
+} from '@/lib/quote-metadata';
+import { generateNextOrderNumber } from '@/lib/orders.server';
+import { prisma } from '@/lib/prisma';
+import { canAccessAdmin } from '@/lib/rbac';
+import { businessNameFromCode, type BusinessCode, type BusinessName } from '@/lib/businesses';
+import { ensureAttachmentRoot, storeAttachmentFile } from '@/lib/storage';
+
+async function requireAdmin() {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new NextResponse('Unauthorized', { status: 401 });
+  }
+
+  const role = (session.user as any)?.role || 'VIEWER';
+  if (!canAccessAdmin(role)) {
+    return new NextResponse('Forbidden', { status: 403 });
+  }
+
+  return { session };
+}
+
+interface PreparedAttachment {
+  url: string | null;
+  storagePath: string | null;
+  label: string | null;
+  mimeType: string | null;
+}
+
+function buildPartNotes(part: { description: string | null; notes: string | null; pieceCount: number }): string | null {
+  const lines: string[] = [];
+  if (part.description) {
+    lines.push(part.description.trim());
+  }
+  if (part.pieceCount > 1) {
+    lines.push(`Pieces: ${part.pieceCount}`);
+  }
+  if (part.notes) {
+    lines.push(part.notes.trim());
+  }
+  const combined = lines.join('\n').trim();
+  return combined.length ? combined : null;
+}
+
+function buildConversionNote(quote: any, now: Date): string | null {
+  const sections: string[] = [`Converted from quote ${quote.quoteNumber} on ${now.toLocaleString()}.`];
+  if (quote.materialSummary) {
+    sections.push(`Materials:\n${quote.materialSummary}`);
+  }
+  if (quote.purchaseItems) {
+    sections.push(`Purchase items:\n${quote.purchaseItems}`);
+  }
+  if (quote.requirements) {
+    sections.push(`Requirements:\n${quote.requirements}`);
+  }
+  if (quote.notes) {
+    sections.push(`Quote notes:\n${quote.notes}`);
+  }
+
+  const content = sections.join('\n\n').trim();
+  return content.length ? content : null;
+}
+
+async function prepareAttachments({
+  attachments,
+  businessName,
+  customerName,
+  orderNumber,
+}: {
+  attachments: Array<{ storagePath: string | null; url: string | null; label: string | null; mimeType: string | null }>;
+  businessName: BusinessName;
+  customerName: string;
+  orderNumber: string;
+}): Promise<PreparedAttachment[]> {
+  if (!attachments.length) return [];
+
+  const prepared: PreparedAttachment[] = [];
+  const attachmentRoot = await ensureAttachmentRoot();
+
+  for (const attachment of attachments) {
+    if (attachment.storagePath) {
+      const sourcePath = path.join(attachmentRoot, attachment.storagePath);
+      let buffer: Buffer;
+      try {
+        buffer = await readFile(sourcePath);
+      } catch (error) {
+        throw new Error(`Unable to read attachment ${attachment.storagePath}`);
+      }
+
+      const stored = await storeAttachmentFile({
+        business: businessName,
+        customerName,
+        referenceNumber: orderNumber,
+        originalFilename: attachment.label || path.basename(sourcePath),
+        buffer,
+      });
+
+      prepared.push({
+        url: null,
+        storagePath: stored.storagePath,
+        label: attachment.label ?? path.basename(stored.storagePath),
+        mimeType: attachment.mimeType ?? null,
+      });
+      continue;
+    }
+
+    if (attachment.url) {
+      prepared.push({
+        url: attachment.url,
+        storagePath: null,
+        label: attachment.label ?? null,
+        mimeType: attachment.mimeType ?? null,
+      });
+    }
+  }
+
+  return prepared;
+}
+
+export async function POST(req: NextRequest, { params }: { params: { id: string } }) {
+  const guard = await requireAdmin();
+  if (guard instanceof NextResponse) return guard;
+
+  const quote = await prisma.quote.findUnique({
+    where: { id: params.id },
+    include: {
+      customer: { select: { id: true, name: true } },
+      parts: true,
+      addonSelections: true,
+      attachments: true,
+    },
+  });
+
+  if (!quote) {
+    return new NextResponse('Not found', { status: 404 });
+  }
+
+  const metadata = mergeQuoteMetadata(parseQuoteMetadata(quote.metadata) ?? DEFAULT_QUOTE_METADATA);
+
+  if (metadata.conversion?.orderId) {
+    return NextResponse.json(
+      { error: `Quote already converted to order ${metadata.conversion.orderNumber}` },
+      { status: 409 },
+    );
+  }
+
+  if (!metadata.approval?.received) {
+    return NextResponse.json({ error: 'Approval must be received before conversion.' }, { status: 400 });
+  }
+
+  if (!quote.customerId) {
+    return NextResponse.json({ error: 'Assign a customer before converting this quote.' }, { status: 400 });
+  }
+
+  const businessCode = quote.business as BusinessCode;
+  const businessName = businessNameFromCode(quote.business) as BusinessName;
+  const customerName = (quote.customer?.name || quote.companyName || 'Customer').trim();
+
+  if (!customerName) {
+    return NextResponse.json({ error: 'Customer information is required before conversion.' }, { status: 400 });
+  }
+
+  const orderNumber = await generateNextOrderNumber(businessCode);
+
+  let orderAttachments: PreparedAttachment[] = [];
+  try {
+    orderAttachments = await prepareAttachments({
+      attachments: quote.attachments,
+      businessName,
+      customerName,
+      orderNumber,
+    });
+  } catch (error: any) {
+    const message = typeof error?.message === 'string' ? error.message : 'Failed to copy attachments';
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+
+  const partsData = quote.parts.map((part) => ({
+    partNumber: part.name,
+    quantity: part.quantity ?? 1,
+    materialId: null,
+    notes: buildPartNotes({
+      description: part.description ?? null,
+      notes: part.notes ?? null,
+      pieceCount: part.pieceCount ?? 1,
+    }),
+  }));
+
+  const addonIds = Array.from(new Set(quote.addonSelections.map((selection) => selection.addonId))).filter(Boolean);
+
+  const now = new Date();
+  const dueDate = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000);
+  const noteContent = buildConversionNote(quote, now);
+  const userId = (guard.session.user as any)?.id as string | undefined;
+
+  const result = await prisma.$transaction(async (tx) => {
+    const order = await tx.order.create({
+      data: {
+        orderNumber,
+        business: quote.business,
+        customerId: quote.customerId,
+        modelIncluded: quote.multiPiece,
+        receivedDate: now,
+        dueDate,
+        priority: 'NORMAL',
+        status: 'RECEIVED',
+        materialNeeded: false,
+        materialOrdered: false,
+        vendorId: null,
+        poNumber: null,
+        assignedMachinistId: null,
+        parts: partsData.length
+          ? {
+              create: partsData.map((part) => ({
+                partNumber: part.partNumber,
+                quantity: part.quantity,
+                materialId: part.materialId,
+                notes: part.notes ?? undefined,
+              })),
+            }
+          : undefined,
+        checklist: addonIds.length
+          ? {
+              create: addonIds.map((addonId) => ({ addonId })),
+            }
+          : undefined,
+        attachments: orderAttachments.length
+          ? {
+              create: orderAttachments.map((attachment) => ({
+                url: attachment.url,
+                storagePath: attachment.storagePath,
+                label: attachment.label,
+                mimeType: attachment.mimeType,
+                uploadedById: userId ?? null,
+              })),
+            }
+          : undefined,
+        notes:
+          noteContent && userId
+            ? {
+                create: {
+                  content: noteContent,
+                  userId,
+                },
+              }
+            : undefined,
+        statusHistory: {
+          create: {
+            from: 'RECEIVED',
+            to: 'RECEIVED',
+            userId,
+            reason: `Converted from quote ${quote.quoteNumber}`,
+          },
+        },
+      },
+      select: { id: true },
+    });
+
+    const updatedMetadata = mergeQuoteMetadata({
+      ...metadata,
+      conversion: {
+        orderId: order.id,
+        orderNumber,
+        convertedAt: now.toISOString(),
+      },
+      approval: metadata.approval,
+    });
+
+    await tx.quote.update({
+      where: { id: quote.id },
+      data: {
+        metadata: stringifyQuoteMetadata(updatedMetadata),
+      },
+    });
+
+    return { orderId: order.id, metadata: updatedMetadata };
+  });
+
+  return NextResponse.json({
+    ok: true,
+    orderId: result.orderId,
+    orderNumber,
+    metadata: result.metadata,
+  });
+}

--- a/src/app/api/admin/quotes/[id]/route.ts
+++ b/src/app/api/admin/quotes/[id]/route.ts
@@ -70,7 +70,10 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
     return NextResponse.json({ error: parsed.error.message }, { status: 400 });
   }
 
-  const existing = await prisma.quote.findUnique({ where: { id: params.id }, select: { quoteNumber: true } });
+  const existing = await prisma.quote.findUnique({
+    where: { id: params.id },
+    select: { quoteNumber: true, metadata: true },
+  });
   if (!existing) {
     return new NextResponse('Not found', { status: 404 });
   }
@@ -103,7 +106,7 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
       vendorTotalCents: prepared.vendorTotalCents,
       addonsTotalCents: prepared.addonsTotalCents,
       totalCents: prepared.totalCents,
-      metadata: stringifyQuoteMetadata(DEFAULT_QUOTE_METADATA),
+      metadata: stringifyQuoteMetadata(parseQuoteMetadata(existing.metadata) ?? DEFAULT_QUOTE_METADATA),
       parts: {
         deleteMany: {},
         create: prepared.parts,

--- a/src/lib/orders.server.ts
+++ b/src/lib/orders.server.ts
@@ -1,0 +1,22 @@
+import { prisma } from '@/lib/prisma';
+import { BUSINESS_PREFIX_BY_CODE, type BusinessCode } from '@/lib/businesses';
+
+export async function generateNextOrderNumber(business: BusinessCode): Promise<string> {
+  const recent = await prisma.order.findMany({
+    select: { orderNumber: true },
+    where: { business },
+    orderBy: { orderNumber: 'desc' },
+    take: 200,
+  });
+
+  let maxValue = 1000;
+  for (const candidate of recent) {
+    const numeric = parseInt(candidate.orderNumber.replace(/[^0-9]/g, ''), 10);
+    if (!Number.isNaN(numeric) && Number.isFinite(numeric)) {
+      maxValue = Math.max(maxValue, numeric);
+    }
+  }
+
+  const prefix = BUSINESS_PREFIX_BY_CODE[business] ?? business;
+  return `${prefix}-${maxValue + 1}`;
+}

--- a/src/lib/quote-metadata.ts
+++ b/src/lib/quote-metadata.ts
@@ -1,18 +1,76 @@
+export interface QuoteApprovalMetadata {
+  received: boolean;
+  attachmentId: string | null;
+  attachmentLabel?: string | null;
+  attachmentStoragePath?: string | null;
+  attachmentUrl?: string | null;
+  uploadedAt?: string | null;
+}
+
+export interface QuoteConversionMetadata {
+  orderId: string | null;
+  orderNumber: string | null;
+  convertedAt?: string | null;
+}
+
 export type QuoteMetadata = Record<string, unknown> & {
   markupSuggestions?: number[];
+  approval?: QuoteApprovalMetadata;
+  conversion?: QuoteConversionMetadata;
+};
+
+const DEFAULT_APPROVAL: QuoteApprovalMetadata = {
+  received: false,
+  attachmentId: null,
+  attachmentLabel: null,
+  attachmentStoragePath: null,
+  attachmentUrl: null,
+  uploadedAt: null,
+};
+
+const DEFAULT_CONVERSION: QuoteConversionMetadata = {
+  orderId: null,
+  orderNumber: null,
+  convertedAt: null,
 };
 
 export const DEFAULT_QUOTE_METADATA: QuoteMetadata = Object.freeze({
   markupSuggestions: [0.1, 0.15, 0.2],
+  approval: DEFAULT_APPROVAL,
+  conversion: DEFAULT_CONVERSION,
 });
 
+function cloneDefaultArray(values: number[] | undefined): number[] | undefined {
+  if (!values) return undefined;
+  return values.slice();
+}
+
+export function mergeQuoteMetadata(metadata: QuoteMetadata | null | undefined): QuoteMetadata {
+  const base = metadata && typeof metadata === 'object' ? metadata : {};
+  const approval =
+    base.approval && typeof base.approval === 'object'
+      ? { ...DEFAULT_APPROVAL, ...base.approval }
+      : { ...DEFAULT_APPROVAL };
+  const conversion =
+    base.conversion && typeof base.conversion === 'object'
+      ? { ...DEFAULT_CONVERSION, ...base.conversion }
+      : { ...DEFAULT_CONVERSION };
+
+  return {
+    ...base,
+    markupSuggestions: Array.isArray(base.markupSuggestions)
+      ? cloneDefaultArray(base.markupSuggestions) ?? cloneDefaultArray(DEFAULT_QUOTE_METADATA.markupSuggestions)
+      : cloneDefaultArray(DEFAULT_QUOTE_METADATA.markupSuggestions),
+    approval,
+    conversion,
+  } satisfies QuoteMetadata;
+}
+
 export function stringifyQuoteMetadata(metadata: QuoteMetadata | null | undefined): string | null {
-  if (!metadata) {
-    return null;
-  }
+  const merged = mergeQuoteMetadata(metadata ?? DEFAULT_QUOTE_METADATA);
 
   try {
-    return JSON.stringify(metadata);
+    return JSON.stringify(merged);
   } catch {
     return null;
   }
@@ -20,13 +78,13 @@ export function stringifyQuoteMetadata(metadata: QuoteMetadata | null | undefine
 
 export function parseQuoteMetadata(value: string | null | undefined): QuoteMetadata | null {
   if (!value) {
-    return null;
+    return mergeQuoteMetadata(DEFAULT_QUOTE_METADATA);
   }
 
   try {
     const parsed = JSON.parse(value);
-    return parsed && typeof parsed === 'object' ? (parsed as QuoteMetadata) : null;
+    return parsed && typeof parsed === 'object' ? mergeQuoteMetadata(parsed as QuoteMetadata) : mergeQuoteMetadata(DEFAULT_QUOTE_METADATA);
   } catch {
-    return null;
+    return mergeQuoteMetadata(DEFAULT_QUOTE_METADATA);
   }
 }


### PR DESCRIPTION
## Summary
- add shared quote workflow controls to capture approval uploads and convert quotes directly from detail and list pages
- expose admin APIs to record approval metadata, clone quote data into new orders, and generate order numbers while copying attachments
- extend quote metadata defaults and document the attachment retention policy for converted quotes

## Testing
- npm run build *(fails: missing generated Prisma client during attachment route build)*
- npm run prisma:generate *(fails: Prisma engine download blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf67989708327892ae6cf2348915f