### PR TITLE
Sanitize addon pricing for non-admin quote views

### DIFF
--- a/src/lib/__tests__/quote-visibility.test.ts
+++ b/src/lib/__tests__/quote-visibility.test.ts
@@ -108,9 +108,11 @@ describe('quote visibility sanitizers', () => {
     expect(result.vendorItems[0].finalPriceCents).toBe(0);
     expect(result.addonSelections[0].rateCents).toBe(0);
     expect(result.addonSelections[0].totalCents).toBe(0);
+    expect(result.addonSelections[0].addon.rateCents).toBe(0);
 
     // Ensure the original object is not mutated
     expect(detailBase.vendorItems[0].finalPriceCents).toBe(3680);
+    expect(detailBase.addonSelections[0].addon.rateCents).toBe(500);
   });
 
   it('returns the original summary payload for admins', () => {

--- a/src/lib/quote-visibility.ts
+++ b/src/lib/quote-visibility.ts
@@ -43,6 +43,12 @@ export function sanitizeQuoteDetailPricing(
       ...selection,
       rateCents: 0,
       totalCents: 0,
+      addon: selection.addon
+        ? {
+            ...selection.addon,
+            rateCents: 0,
+          }
+        : selection.addon,
     })),
   };
 }


### PR DESCRIPTION
## Summary
- zero out addon selection addon.rateCents when sanitizing quote details for non-admins
- extend unit coverage to confirm nested addon pricing is scrubbed while leaving admin behavior unchanged

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68dc13b8c95c8327a4ade90496f88a97