### PR TITLE
Fix Prisma schema enums for SQLite compatibility

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -7,12 +7,6 @@ datasource db {
   url      = env("DATABASE_URL")
 }
 
-enum Business {
-  STD
-  CRM
-  PC
-}
-
 model User {
   id               String   @id @default(cuid())
   email            String   @unique
@@ -72,7 +66,7 @@ model Vendor {
 model Order {
   id               String   @id @default(cuid())
   orderNumber      String
-  business         Business @default(STD)
+  business         String   @default("STD")
   customerId       String
   customer         Customer @relation(fields: [customerId], references: [id])
   status           String
@@ -189,7 +183,7 @@ model Addon {
 model Quote {
   id               String   @id @default(cuid())
   quoteNumber      String
-  business         Business @default(STD)
+  business         String   @default("STD")
   companyName      String
   contactName      String?
   contactEmail     String?


### PR DESCRIPTION
## Summary
- remove the unsupported Business enum from the Prisma schema when using the SQLite connector
- keep the business fields on Order and Quote as strings with defaults to maintain existing behaviour

## Testing
- pnpm prisma generate *(fails: Prisma engine checksum download blocked by 403 in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dc172d1bb88327ae6cad3e192df4bd