### PR TITLE
Add creation date sorting to dashboards

### DIFF
--- a/src/app/orders/page.tsx
+++ b/src/app/orders/page.tsx
@@ -34,7 +34,7 @@ import {
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { BUSINESS_OPTIONS } from '@/lib/businesses';
 
-const SORT_KEYS = ['dueDate', 'priority', 'status'] as const;
+const SORT_KEYS = ['dueDate', 'receivedDate', 'priority', 'status'] as const;
 const PRIORITY_FILTERS = ['all', 'HOT', 'RUSH', 'NORMAL', 'LOW'] as const;
 const STATUS_FILTERS = ['all', 'active', 'closed'] as const;
 const UNASSIGNED_VALUE = '__unassigned__';
@@ -123,8 +123,14 @@ export default function OrdersPage() {
       if (!A && !B) return 0;
       if (!A) return 1;
       if (!B) return -1;
-      if (sortKey === 'dueDate')
-        return (new Date(A).getTime() - new Date(B).getTime()) * (sortDir === 'asc' ? 1 : -1);
+      if (sortKey === 'dueDate' || sortKey === 'receivedDate') {
+        const timeA = new Date(A as any).getTime();
+        const timeB = new Date(B as any).getTime();
+        if (Number.isNaN(timeA) && Number.isNaN(timeB)) return 0;
+        if (Number.isNaN(timeA)) return 1;
+        if (Number.isNaN(timeB)) return -1;
+        return (timeA - timeB) * (sortDir === 'asc' ? 1 : -1);
+      }
       return String(A).localeCompare(String(B)) * (sortDir === 'asc' ? 1 : -1);
     });
     return arr;
@@ -279,6 +285,7 @@ export default function OrdersPage() {
                   </SelectTrigger>
                   <SelectContent>
                     <SelectItem value="dueDate">Due date</SelectItem>
+                    <SelectItem value="receivedDate">Creation date</SelectItem>
                     <SelectItem value="priority">Priority</SelectItem>
                     <SelectItem value="status">Status</SelectItem>
                   </SelectContent>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,51 +1,18 @@
 import Link from 'next/link';
 import { redirect } from 'next/navigation';
-import { format } from 'date-fns';
-import {
-  Activity,
-  ArrowUpRight,
-  CalendarDays,
-  CircleCheck,
-  Users,
-} from 'lucide-react';
+import { Activity, ArrowUpRight, CalendarDays, CircleCheck, Users } from 'lucide-react';
 import { getServerSession } from 'next-auth';
 
-import { authOptions } from '@/lib/auth';
-import { prisma } from '@/lib/prisma';
-import { cn } from '@/lib/utils';
+import { RecentOrdersTable } from '@/components/RecentOrdersTable';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/Button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/Card';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-
-const STATUS_LABELS: Record<string, string> = {
-  RECEIVED: 'Received',
-  PROGRAMMING: 'Programming',
-  SETUP: 'Setup',
-  RUNNING: 'Running',
-  FINISHING: 'Finishing',
-  DONE_MACHINING: 'Machining Done',
-  INSPECTION: 'Inspection',
-  SHIPPING: 'Shipping',
-  CLOSED: 'Closed',
-};
-
-function getInitials(value?: string | null) {
-  if (!value) return 'SA';
-  const parts = value.split(' ').filter(Boolean);
-  if (!parts.length) return value.slice(0, 2).toUpperCase();
-  return parts
-    .slice(0, 2)
-    .map((p) => p[0]?.toUpperCase() ?? '')
-    .join('');
-}
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/Card';
+import { authOptions } from '@/lib/auth';
+import { getInitials } from '@/lib/get-initials';
+import { prisma } from '@/lib/prisma';
+import { ORDER_STATUS_LABELS } from '@/lib/order-status-labels';
+import { cn } from '@/lib/utils';
 
 export default async function Home() {
   const session = await getServerSession(authOptions);
@@ -182,58 +149,7 @@ export default async function Home() {
             </Button>
           </CardHeader>
           <CardContent>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Order</TableHead>
-                  <TableHead className="hidden lg:table-cell">Customer</TableHead>
-                  <TableHead className="hidden xl:table-cell">Status</TableHead>
-                  <TableHead className="hidden xl:table-cell">Machinist</TableHead>
-                  <TableHead className="text-right">Due</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {recentOrders.map((order) => (
-                  <TableRow key={order.id} className="border-border/60">
-                    <TableCell className="font-medium">
-                      <div className="flex flex-col">
-                        <Link href={`/orders/${order.id}`} className="text-sm font-semibold text-primary hover:underline">
-                          #{order.orderNumber}
-                        </Link>
-                        <span className="text-xs text-muted-foreground">{format(order.receivedDate, 'MMM d, yyyy')}</span>
-                      </div>
-                    </TableCell>
-                    <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
-                      {order.customer?.name ?? '—'}
-                    </TableCell>
-                    <TableCell className="hidden xl:table-cell">
-                      <Badge variant="outline" className="border-primary/40 bg-primary/10 text-[0.7rem] uppercase tracking-wide">
-                        {STATUS_LABELS[order.status] ?? order.status}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="hidden xl:table-cell">
-                      <div className="flex items-center gap-2">
-                        {order.assignedMachinist ? (
-                          <Avatar className="h-8 w-8 border border-primary/40 bg-secondary/40">
-                            <AvatarFallback>{getInitials(order.assignedMachinist.name)}</AvatarFallback>
-                          </Avatar>
-                        ) : (
-                          <div className="flex h-8 w-8 items-center justify-center rounded-full border border-primary/30 bg-secondary/30 text-xs uppercase text-muted-foreground">
-                            NA
-                          </div>
-                        )}
-                        <span className="text-sm text-muted-foreground">
-                          {order.assignedMachinist?.name ?? 'Unassigned'}
-                        </span>
-                      </div>
-                    </TableCell>
-                    <TableCell className="text-right text-sm text-muted-foreground">
-                      {format(order.dueDate, 'MMM d')}
-                    </TableCell>
-                  </TableRow>
-                ))}
-              </TableBody>
-            </Table>
+            <RecentOrdersTable orders={recentOrders} />
           </CardContent>
         </Card>
 
@@ -279,7 +195,7 @@ export default async function Home() {
                 return (
                   <div key={status} className="space-y-2">
                     <div className="flex items-center justify-between text-xs uppercase tracking-wide text-muted-foreground">
-                      <span>{STATUS_LABELS[status] ?? status}</span>
+                      <span>{ORDER_STATUS_LABELS[status] ?? status}</span>
                       <span>{count}</span>
                     </div>
                     <div className="h-2 overflow-hidden rounded-full bg-secondary/50">

--- a/src/components/RecentOrdersTable.tsx
+++ b/src/components/RecentOrdersTable.tsx
@@ -1,0 +1,150 @@
+"use client";
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { format } from 'date-fns';
+
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { getInitials } from '@/lib/get-initials';
+import { ORDER_STATUS_LABELS } from '@/lib/order-status-labels';
+
+type SortOption = 'dueDate' | 'receivedDate';
+
+type RecentOrder = {
+  id: string;
+  orderNumber: string;
+  dueDate: string | Date | null;
+  receivedDate: string | Date | null;
+  status: string;
+  customer?: { name?: string | null } | null;
+  assignedMachinist?: { name?: string | null } | null;
+};
+
+const SORT_LABELS: Record<SortOption, string> = {
+  dueDate: 'Due date',
+  receivedDate: 'Creation date',
+};
+
+function parseDate(value: string | Date | null | undefined) {
+  if (!value) return null;
+  const date = value instanceof Date ? value : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+export function RecentOrdersTable({ orders }: { orders: RecentOrder[] }) {
+  const [sortKey, setSortKey] = useState<SortOption>('dueDate');
+
+  const sortedOrders = useMemo(() => {
+    const list = Array.from(orders);
+    return list.sort((a, b) => {
+      const dateA = parseDate(a[sortKey]);
+      const dateB = parseDate(b[sortKey]);
+
+      if (!dateA && !dateB) return 0;
+      if (!dateA) return 1;
+      if (!dateB) return -1;
+
+      if (sortKey === 'dueDate') {
+        return dateA.getTime() - dateB.getTime();
+      }
+
+      return dateB.getTime() - dateA.getTime();
+    });
+  }, [orders, sortKey]);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-end gap-3">
+        <Label htmlFor="recent-orders-sort" className="text-xs uppercase tracking-wide text-muted-foreground">
+          Sort by
+        </Label>
+        <Select value={sortKey} onValueChange={(value) => setSortKey(value as SortOption)}>
+          <SelectTrigger
+            id="recent-orders-sort"
+            className="w-[180px] border-border/60 bg-background/80"
+            aria-label="Sort recent orders"
+          >
+            <SelectValue placeholder="Sort column" />
+          </SelectTrigger>
+          <SelectContent>
+            {Object.entries(SORT_LABELS).map(([value, label]) => (
+              <SelectItem key={value} value={value}>
+                {label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Order</TableHead>
+            <TableHead className="hidden lg:table-cell">Customer</TableHead>
+            <TableHead className="hidden xl:table-cell">Status</TableHead>
+            <TableHead className="hidden xl:table-cell">Machinist</TableHead>
+            <TableHead className="text-right">Due</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {sortedOrders.map((order) => {
+            const dueDate = parseDate(order.dueDate);
+            const receivedDate = parseDate(order.receivedDate);
+
+            return (
+              <TableRow key={order.id} className="border-border/60">
+                <TableCell className="font-medium">
+                  <div className="flex flex-col">
+                    <Link href={`/orders/${order.id}`} className="text-sm font-semibold text-primary hover:underline">
+                      #{order.orderNumber}
+                    </Link>
+                    <span className="text-xs text-muted-foreground">
+                      {receivedDate ? format(receivedDate, 'MMM d, yyyy') : 'TBD'}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell className="hidden lg:table-cell text-sm text-muted-foreground">
+                  {order.customer?.name ?? '—'}
+                </TableCell>
+                <TableCell className="hidden xl:table-cell">
+                  <Badge variant="outline" className="border-primary/40 bg-primary/10 text-[0.7rem] uppercase tracking-wide">
+                    {ORDER_STATUS_LABELS[order.status] ?? order.status}
+                  </Badge>
+                </TableCell>
+                <TableCell className="hidden xl:table-cell">
+                  <div className="flex items-center gap-2">
+                    {order.assignedMachinist?.name ? (
+                      <Avatar className="h-8 w-8 border border-primary/40 bg-secondary/40">
+                        <AvatarFallback>{getInitials(order.assignedMachinist.name)}</AvatarFallback>
+                      </Avatar>
+                    ) : (
+                      <div className="flex h-8 w-8 items-center justify-center rounded-full border border-primary/30 bg-secondary/30 text-xs uppercase text-muted-foreground">
+                        NA
+                      </div>
+                    )}
+                    <span className="text-sm text-muted-foreground">
+                      {order.assignedMachinist?.name ?? 'Unassigned'}
+                    </span>
+                  </div>
+                </TableCell>
+                <TableCell className="text-right text-sm text-muted-foreground">
+                  {dueDate ? format(dueDate, 'MMM d') : 'TBD'}
+                </TableCell>
+              </TableRow>
+            );
+          })}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/src/lib/get-initials.ts
+++ b/src/lib/get-initials.ts
@@ -1,0 +1,9 @@
+export function getInitials(value?: string | null) {
+  if (!value) return 'SA';
+  const parts = value.split(' ').filter(Boolean);
+  if (!parts.length) return value.slice(0, 2).toUpperCase();
+  return parts
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? '')
+    .join('');
+}

--- a/src/lib/order-status-labels.ts
+++ b/src/lib/order-status-labels.ts
@@ -1,0 +1,11 @@
+export const ORDER_STATUS_LABELS: Record<string, string> = {
+  RECEIVED: 'Received',
+  PROGRAMMING: 'Programming',
+  SETUP: 'Setup',
+  RUNNING: 'Running',
+  FINISHING: 'Finishing',
+  DONE_MACHINING: 'Machining Done',
+  INSPECTION: 'Inspection',
+  SHIPPING: 'Shipping',
+  CLOSED: 'Closed',
+};


### PR DESCRIPTION
## Summary
- add a creation date option to the Orders overview sort controls alongside the existing fields
- refactor the Shop Intelligence overview table into a client component with creation-date sorting and shared helpers

## Testing
- pnpm lint *(fails: Command "lint" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68deb02e7cd083279fd7a206e19c8ac6