### PR TITLE
[codex] Fix order detail department defaults and compact timer dock

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -197,6 +197,26 @@ Agents MUST update this at the end of every session.
 
 ## Session Log (append newest at top)
 
+### 2026-04-09 — Order-detail follow-up: persisted Machining default + manual-only department presentation + compact timer dock
+- Fixed order part ownership initialization so newly created/converted order parts now persist the first active department immediately instead of sitting with null `currentDepartmentId`.
+- Fixed order-detail read-model behavior so a part with missing department ownership no longer appears to auto-advance to the next department when the last checklist item in the current department is checked; missing ownership now falls back only to the first active department.
+- Updated `/orders/[id]` left rail to reduce timer footprint:
+  - narrowed the left rail,
+  - shortened timer/action labels,
+  - defaulted the manual move action toward the next ordered department,
+  - moved detailed time notes/history behind an explicit `Show details` toggle so the parts list keeps more vertical space.
+- Added focused Orders service regression coverage proving:
+  - new parts initialize to Machining/first department,
+  - a null-owned part does not visually jump to the next department after checklist completion.
+
+Commands run:
+- `npm run test -- src/modules/orders/__tests__/orders.service.test.ts`
+- `npm run lint`
+
+Verification note:
+- Targeted Orders service tests passed (7/7).
+- Lint passed with no ESLint warnings/errors.
+
 ### 2026-04-08 — Final phase complete: structured quote template block editor + print mapping
 - Extended document template layout normalization from legacy `sections[]` into structured `blocks[]` model (`id`, `type`, `label`, `visible`, `order`, `variant`, `options`) with backward-compatible fallback.
 - Upgraded `/admin/templates` builder to block-based editing with controls for show/hide, label override, variant preset, and quote pricing block options (`showUnitPrice`, `showQuantity`, `showLineTotal`, `showPricingMode`).

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -60,6 +60,10 @@ Goal: a scalable foundation that can grow.
 
 ## Decision Log (append newest at top)
 
+### 2026-04-09 — Missing part department ownership must default to first department, never inferred next-step routing
+Decision: When an order part has no persisted `currentDepartmentId`, read models and initialization/backfill paths must assign the first active department in ordering (currently Machining) instead of inferring ownership from whichever checklist department still has open items.
+Reason: Inferring department from checklist state makes last-item completion look like an automatic department move, which conflicts with the manual-submit workflow and obscures true ownership after quote conversion or other uninitialized-part paths.
+
 
 ### 2026-04-08 — Dashboard/work-queue department ownership follows current department, not checklist presence
 Decision: Dashboard department displays and work-queue ownership should be driven by `OrderPart.currentDepartmentId`; department feed visibility must not depend on whether that same department still has open checklist rows.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -2677,3 +2677,46 @@ Goal (1 sentence): Fix the `/orders/[id]` compile error caused by mixing `??` wi
 - [ ] User verify `/orders/[id]` and `/admin` load again without the compile-time 500s.
 
 ---
+## Session Handoff — 2026-04-09 (Order-detail department + timer follow-up)
+
+Goal (1 sentence): Make converted/new orders default part ownership to Machining/first department, stop apparent checklist-driven auto department moves on order detail, and reduce the timer panel footprint so parts stay visually primary.
+
+### What changed
+- Updated `src/modules/orders/orders.service.ts`
+  - Added `initializeCurrentDepartmentForOrder(orderId)` helper.
+  - `createOrderFromPayload()` now initializes part ownership immediately after order creation/checklist sync.
+  - `getOrderDetails()` no longer infers a missing `currentDepartmentId` from open checklist rows; it now falls back only to the first active department.
+  - Missing-department backfill/initialization now assigns the first active department instead of deriving a later stage from checklist completion.
+- Updated `src/app/api/admin/quotes/[id]/convert/route.ts`
+  - Quote conversion now initializes order-part department ownership right after checklist sync, so converted parts persist the default first department immediately.
+- Updated `src/app/orders/[id]/page.tsx`
+  - Narrowed the left rail from `360px` to `320px`.
+  - Shortened timer status/action labels and changed the manual move CTA to default toward the next ordered department (`Submit to ...`).
+  - Added a `Show details` toggle so time-history and manual time notes no longer consume left-rail space by default.
+- Updated `src/modules/orders/__tests__/orders.service.test.ts`
+  - Added regression coverage proving new parts initialize to Machining/first department.
+  - Added regression coverage proving a null-owned part does not visually jump to the next department after checklist completion.
+- Updated continuity docs and added Decision Log entry in `docs/AGENT_CONTEXT.md`.
+
+### Files touched
+- `src/modules/orders/orders.service.ts`
+- `src/app/api/admin/quotes/[id]/convert/route.ts`
+- `src/app/orders/[id]/page.tsx`
+- `src/modules/orders/__tests__/orders.service.test.ts`
+- `docs/AGENT_CONTEXT.md`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm run test -- src/modules/orders/__tests__/orders.service.test.ts`
+- `npm run lint`
+
+### Verification evidence
+- Targeted Orders service tests passed (7/7).
+- Lint passed with no ESLint warnings/errors.
+
+### Next steps
+- [ ] User verify on `/orders/[id]` that converted parts now land in Machining/current first department instead of showing `Unassigned`.
+- [ ] User verify that checking the last checklist item no longer makes the part appear to auto-move departments before using the manual submit/move action.
+- [ ] Optional follow-up: if the owner wants an even more aggressive left-rail reduction, split timer controls and part list into separate stacked cards on mobile/tablet breakpoints only.

--- a/src/app/api/admin/quotes/[id]/convert/route.ts
+++ b/src/app/api/admin/quotes/[id]/convert/route.ts
@@ -17,7 +17,11 @@ import { businessNameFromCode, type BusinessCode, type BusinessName } from '@/li
 import { ensureAttachmentRoot, storeAttachmentFile } from '@/lib/storage';
 import { OrderPartCreate, PriorityEnum } from '@/modules/orders/orders.schema';
 import { getAppSettings } from '@/lib/app-settings';
-import { ensureOrderFilesInCanonicalStorage, syncChecklistForOrder } from '@/modules/orders/orders.service';
+import {
+  ensureOrderFilesInCanonicalStorage,
+  initializeCurrentDepartmentForOrder,
+  syncChecklistForOrder,
+} from '@/modules/orders/orders.service';
 import { hasCustomFieldValue, serializeCustomFieldValue } from '@/lib/custom-field-values';
 import { convertQuoteToOrder, findActiveOrderCustomFields, findQuoteForConversion } from '@/modules/quotes/quotes.service';
 
@@ -319,6 +323,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ id:
     });
 
     await syncChecklistForOrder(result.orderId);
+    await initializeCurrentDepartmentForOrder(result.orderId);
     await ensureOrderFilesInCanonicalStorage(result.orderId);
 
     return NextResponse.json({

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -157,6 +157,7 @@ export default function OrderDetailPage() {
     note: '',
     error: null,
   });
+  const [showTimerDetails, setShowTimerDetails] = useState(false);
 
   const parts = useMemo(() => (Array.isArray(item?.parts) ? item.parts : []), [item?.parts]);
   const partIdsParam = useMemo(() => parts.map((part: any) => part.id).filter(Boolean).join(','), [parts]);
@@ -555,7 +556,13 @@ export default function OrderDetailPage() {
   const openMoveDepartmentDialog = () => {
     if (!selectedPartId) return;
     const currentDepartmentId = selectedPart?.currentDepartmentId ?? '';
+    const currentDepartmentIndex = manualMoveDepartments.findIndex((department) => department.id === currentDepartmentId);
     const defaultDepartmentId =
+      (currentDepartmentIndex >= 0
+        ? manualMoveDepartments
+            .slice(currentDepartmentIndex + 1)
+            .find((department) => department.id !== currentDepartmentId)?.id
+        : undefined) ??
       manualMoveDepartments.find((department) => department.id !== currentDepartmentId)?.id ??
       manualMoveDepartments[0]?.id ??
       '';
@@ -992,9 +999,16 @@ export default function OrderDetailPage() {
     : 0;
   const selectedPartElapsedSeconds = activeOnSelected ? selectedPartStoredSeconds + selectedActiveElapsedSeconds : selectedPartStoredSeconds;
   const hasActiveEntry = activeEntries.length > 0;
-  const startButtonLabel = 'Start selected part';
   const startHelperLabel = 'Starts a timer on the selected part for the selected department. Department moves are manual only.';
   const selectedCurrentDepartment = manualMoveDepartments.find((department) => department.id === selectedPart?.currentDepartmentId) ?? null;
+  const selectedCurrentDepartmentIndex = selectedCurrentDepartment
+    ? manualMoveDepartments.findIndex((department) => department.id === selectedCurrentDepartment.id)
+    : -1;
+  const nextDepartmentOption =
+    selectedCurrentDepartmentIndex >= 0
+      ? manualMoveDepartments[selectedCurrentDepartmentIndex + 1] ?? null
+      : manualMoveDepartments[0] ?? null;
+  const moveActionLabel = nextDepartmentOption ? `Submit to ${nextDepartmentOption.name}` : 'Move part to department';
   const canMarkPartComplete = (selectedCurrentDepartment?.name ?? '').trim().toLowerCase() === 'shipping';
 
   return (
@@ -1127,19 +1141,19 @@ export default function OrderDetailPage() {
               Cancel
             </Button>
             <Button type="button" onClick={() => void handleSubmitDepartmentComplete()} disabled={timerSaving}>
-              {timerSaving ? 'Moving…' : 'Move part'}
+              {timerSaving ? 'Moving…' : moveActionLabel}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
-      <div className="grid gap-6 lg:grid-cols-[360px_1fr]">
+      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
         <Card className="flex flex-col">
           <div className="sticky top-0 z-10 border-b border-border/60 bg-background/95 p-4">
             <div className="grid gap-3">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div className="space-y-1">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Active Work</div>
+                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Work Dock</div>
                   <div className="text-sm font-medium text-foreground">
                     {selectedPart?.partNumber || 'No part selected'}
                   </div>
@@ -1148,11 +1162,11 @@ export default function OrderDetailPage() {
                   </div>
                 </div>
                 <Badge className={hasActiveEntry ? 'bg-emerald-500/15 text-emerald-200' : 'bg-muted text-foreground'}>
-                  {activeOnSelected ? 'Timer running for selected department' : hasActiveEntry ? 'Other department timers running' : 'Timer paused/stopped'}
+                  {activeOnSelected ? 'Running' : hasActiveEntry ? 'Other timer live' : 'Idle'}
                 </Badge>
               </div>
 
-              <div className="grid gap-2">
+              <div className="grid gap-2 sm:grid-cols-2">
                 <Select value={selectedTimerDepartmentId} onValueChange={setSelectedTimerDepartmentId}>
                   <SelectTrigger className="h-8">
                     <SelectValue placeholder="Choose timer department" />
@@ -1173,7 +1187,7 @@ export default function OrderDetailPage() {
                   className="justify-start gap-2"
                 >
                   <Play className="h-4 w-4" />
-                  {startButtonLabel}
+                  Start timer
                 </Button>
                 <Button
                   type="button"
@@ -1184,7 +1198,7 @@ export default function OrderDetailPage() {
                   className="justify-start gap-2"
                 >
                   <PauseCircle className="h-4 w-4" />
-                  Pause active timer
+                  Pause
                 </Button>
                 <Button
                   type="button"
@@ -1195,7 +1209,7 @@ export default function OrderDetailPage() {
                   className="justify-start gap-2"
                 >
                   <Square className="h-4 w-4" />
-                  Stop timer
+                  Stop
                 </Button>
                 <Button
                   type="button"
@@ -1206,7 +1220,7 @@ export default function OrderDetailPage() {
                   className="justify-start gap-2"
                 >
                   <CheckCircle2 className="h-4 w-4" />
-                  Move part to department
+                  {nextDepartmentOption ? `Submit to ${nextDepartmentOption.name}` : 'Move part to department'}
                 </Button>
                 <Button
                   type="button"
@@ -1217,7 +1231,7 @@ export default function OrderDetailPage() {
                   className="justify-start gap-2"
                 >
                   <CheckCircle2 className="h-4 w-4" />
-                  Mark part complete (Shipping)
+                  Complete in Shipping
                 </Button>
               </div>
 
@@ -1247,8 +1261,19 @@ export default function OrderDetailPage() {
               <div className="mt-3 rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
                 <div><span className="font-medium text-foreground">Total time:</span> {formatDuration(selectedPartStoredSeconds)}</div>
                 <div>Timer time: {formatDuration(selectedPartTimerSeconds)}</div>
-                <div>Manual added time: {formatDuration(selectedPartManualSeconds)}</div>
-                {partManualAdjustments.length ? (
+                <div className="flex items-center justify-between gap-3">
+                  <span>Manual added time: {formatDuration(selectedPartManualSeconds)}</span>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => setShowTimerDetails((prev) => !prev)}
+                    className="h-7 px-2 text-xs"
+                  >
+                    {showTimerDetails ? 'Hide details' : 'Show details'}
+                  </Button>
+                </div>
+                {showTimerDetails && partManualAdjustments.length ? (
                   <div className="mt-2 space-y-1">
                     {partManualAdjustments.map((adjustment: any) => (
                       <div key={adjustment.id}>
@@ -1257,10 +1282,10 @@ export default function OrderDetailPage() {
                     ))}
                   </div>
                 ) : null}
-                {selectedPartDepartmentHistory.length ? (
+                {showTimerDetails && selectedPartDepartmentHistory.length ? (
                   <div className="mt-3 space-y-2">
                     <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Department history totals</div>
-                    <div className="grid gap-2 md:grid-cols-3">
+                    <div className="grid gap-2">
                       {selectedPartDepartmentHistory.map((group) => (
                         <div key={group.departmentId ?? '__none__'} className="rounded border border-border/60 bg-background/70 p-2">
                           <div className="text-[11px] text-muted-foreground">{group.departmentName}</div>
@@ -1272,7 +1297,7 @@ export default function OrderDetailPage() {
                       {selectedPartDepartmentHistory.map((group) => (
                         <div key={`${group.departmentId ?? '__none__'}_rows`} className="rounded border border-border/50 bg-background/50 p-2">
                           <div className="mb-1 text-[11px] font-medium text-foreground">{group.departmentName}</div>
-                          {group.entries.slice(0, 5).map((entry: any) => (
+                          {group.entries.slice(0, 3).map((entry: any) => (
                             <div key={entry.id} className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
                               <span>{new Date(entry.startedAt).toLocaleString()}</span>
                               <span className="font-medium text-foreground">{formatDuration(entry.durationSeconds)}</span>

--- a/src/modules/orders/__tests__/orders.service.test.ts
+++ b/src/modules/orders/__tests__/orders.service.test.ts
@@ -84,8 +84,8 @@ describe('orders.service completion gating', () => {
     expect((result as { ok: false; error: string }).error).toContain('note is required');
   });
 
-  it('defaults unassigned parts to the first active department in order details', async () => {
-    const { createOrderFromPayload, backfillCurrentDepartmentIds, getOrderDetails } = await import('../orders.service');
+  it('initializes new order parts to the first active department in order details', async () => {
+    const { createOrderFromPayload, getOrderDetails } = await import('../orders.service');
 
     const created = await createOrderFromPayload({
       business: 'STD',
@@ -117,7 +117,6 @@ describe('orders.service completion gating', () => {
     });
 
     expect(created.ok).toBe(true);
-    await backfillCurrentDepartmentIds();
 
     const orderId = (created as { ok: true; data: { id: string } }).data.id;
     const details = await getOrderDetails(orderId, true);
@@ -126,6 +125,31 @@ describe('orders.service completion gating', () => {
     const payload = (details as { ok: true; data: { item: { parts: Array<{ currentDepartmentId: string | null }> }; departments: Array<{ id: string; name: string }> } }).data;
     expect(payload.departments[0]?.name).toBe('Machining');
     expect(payload.item.parts[0]?.currentDepartmentId).toBe(payload.departments[0]?.id);
+  });
+
+  it('does not visually auto-advance a null-owned part to the next department after checklist completion', async () => {
+    const { getOrderDetails, toggleChecklistItem } = await import('../orders.service');
+    const { updateOrderPart } = await import('@/repos/orders');
+
+    await updateOrderPart('part_test_002', { currentDepartmentId: null, status: 'IN_PROGRESS' });
+
+    const toggle = await toggleChecklistItem({
+      orderId: 'order_test_001',
+      checklistId: 'checklist_test_001',
+      checked: true,
+      togglerId: 'user_test_machinist',
+      employeeName: 'Test Machinist',
+    });
+    expect(toggle.ok).toBe(true);
+
+    const details = await getOrderDetails('order_test_001', true);
+    expect(details.ok).toBe(true);
+
+    const payload = (details as { ok: true; data: { item: { parts: Array<{ id: string; currentDepartmentId: string | null }> }; departments: Array<{ id: string; name: string }> } }).data;
+    const part = payload.item.parts.find((entry) => entry.id === 'part_test_002');
+    expect(payload.departments[0]?.name).toBe('Machining');
+    expect(part?.currentDepartmentId).toBe(payload.departments[0]?.id);
+    expect(part?.currentDepartmentId).not.toBe('dept_test_002');
   });
 
   it('includes parts in the department feed based on current department ownership', async () => {

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -491,6 +491,7 @@ export async function createOrderFromPayload(body: OrderCreateInput, userId?: st
     }
   }
 
+  await initializeCurrentDepartmentForOrder(created.id);
   await syncOrderWorkflowStatus(created.id, { userId: userId ?? null });
   await ensureOrderFilesInCanonicalStorage(created.id);
   return ok({ id: created.id });
@@ -583,13 +584,7 @@ export async function getOrderDetails(id: string, isAdmin: boolean) {
         const fallbackDepartmentId =
           isComplete
             ? null
-            : part.currentDepartmentId ??
-              selectDepartmentForPart(
-                (Array.isArray(sanitized.checklist) ? sanitized.checklist : []).filter((entry: any) => entry.partId === part.id),
-                departments,
-              ) ??
-              departments[0]?.id ??
-              null;
+            : part.currentDepartmentId ?? departments[0]?.id ?? null;
         return {
           ...part,
           currentDepartmentId: fallbackDepartmentId,
@@ -930,13 +925,18 @@ async function initializeCurrentDepartmentForParts({ orderId }: { orderId?: stri
 
   for (const part of parts) {
     if (part.status === 'COMPLETE') continue;
-    const targetDepartmentId = selectDepartmentForPart(part.checklistItems ?? [], departments) ?? departments[0]?.id ?? null;
+    const targetDepartmentId = departments[0]?.id ?? null;
     if (!targetDepartmentId) continue;
     await updateOrderPart(part.id, { currentDepartmentId: targetDepartmentId, status: 'IN_PROGRESS' });
     updatedCount += 1;
   }
 
   return { updatedCount };
+}
+
+export async function initializeCurrentDepartmentForOrder(orderId: string) {
+  const result = await initializeCurrentDepartmentForParts({ orderId });
+  return ok({ orderId, updatedCount: result.updatedCount });
 }
 
 export async function backfillCurrentDepartmentIds() {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,37 @@
 # tasks/todo.md — Session Plan + Verification
 
 ## Session Metadata
+- Date: 2026-04-09
+- Agent: Codex GPT-5
+- Task ID: Order detail department default + timer density + manual-only progression
+- Goal: Make converted/new orders default parts to Machining/first department, stop any apparent checklist-driven auto department progression, and redesign the order-detail timer area so parts stay spatially primary.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated current gaps in code:
+  - quote conversion creates order parts without initializing `currentDepartmentId`,
+  - order-detail read model infers department from open checklist rows when `currentDepartmentId` is null, which makes last-checklist completion look like an automatic move,
+  - `/orders/[id]` timer panel is vertically oversized and competes with the parts list.
+
+## Plan First
+- [x] Update Orders service so missing `currentDepartmentId` falls back only to the first active department, not checklist-derived next-department inference.
+- [x] Add a scoped order-department initialization helper and invoke it after quote conversion so converted orders persist the Machining/first-department owner immediately.
+- [x] Rework `/orders/[id]` left rail into a more compact timer control dock with collapsible time-history details and manual-next-department wording/defaults.
+- [x] Add focused Orders service regression coverage for the manual-only read-model behavior and run relevant verification commands.
+- [x] Update continuity docs with evidence and next steps.
+
+## Verification Checklist
+- [x] `npm run test -- src/modules/orders/__tests__/orders.service.test.ts`
+- [x] `npm run lint`
+
+## Review + Results
+- Converted/new orders now initialize part ownership to the first active department immediately, and order-detail read models no longer infer “next department” from checklist completion when `currentDepartmentId` is missing.
+- The manual-only progression rule is preserved in both persistence and presentation: last-item checklist completion no longer makes a blank-owned part appear to auto-advance.
+- The order-detail timer area now keeps its detailed history behind an explicit toggle, shortens action labels, defaults the manual move dialog toward the next department, and gives the parts list more usable vertical space.
+
+---
+
+## Session Metadata
 - Date: 2026-04-08
 - Agent: GPT-5.3-Codex
 - Task ID: Order-detail department UX follow-up


### PR DESCRIPTION
## What changed
- initialize new and quote-converted order parts to the first active department immediately
- stop order detail from inferring a missing part department from checklist state, which made last-item completion look like an automatic department move
- tighten the `/orders/[id]` left rail so the timer area takes less space and detailed time history is behind an explicit toggle
- add focused Orders service regression coverage for the new defaulting and manual-only presentation behavior

## Why
Parts were showing as unassigned after conversion, and in null-department cases the order-detail read model could make a part appear to jump departments when the last checklist item was checked. The timer card was also taking up too much left-rail space relative to the parts list.

## Impact
- converted and newly created orders now land in Machining or the first configured department immediately
- operators keep manual control over department progression and no longer see a misleading automatic move on checklist completion
- the order detail page gives more space back to the parts list while preserving timer history on demand

## Root cause
Part ownership was not being persisted during some creation/conversion paths, and the order-detail read model tried to reconstruct ownership from open checklist rows. That reconstruction conflicted with the newer manual-submit workflow.

## Validation
- `npm run test -- src/modules/orders/__tests__/orders.service.test.ts`
- `npm run lint`