### PR TITLE
[codex] Polish order work dock timer and department cues

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -197,6 +197,32 @@ Agents MUST update this at the end of every session.
 
 ## Session Log (append newest at top)
 
+### 2026-04-09 — Dashboard follow-up: current department card no longer says `Unassigned` for active fallback-owned work
+- Fixed `src/components/ShopFloorLayouts.tsx` so dashboard/grid-digest current-department labels now use the same first-department fallback as the order-detail workflow for non-complete orders.
+- This removes the contradiction where a part could be treated as Machining in move/timer flows but still render as `Unassigned` on the summary card.
+- Completed/closed orders still skip the fallback so we do not invent an active department after completion.
+
+Commands run:
+- `npm run lint`
+
+Verification note:
+- Lint passed with no ESLint warnings/errors.
+
+### 2026-04-09 — Order-detail follow-up: active timer deep-link + compact submit destination control
+- Updated `/orders/[id]` work dock so the `Other timer live` status now opens the exact active timer context instead of leaving operators guessing:
+  - active timer summaries now include order/part context and deep links,
+  - order detail now honors `?part=` so the link opens directly on the active part when available.
+- Reworked the manual department-submit controls to avoid long button overflow:
+  - replaced `Submit to <Department>` dock copy with a compact `Submit To` button,
+  - added a paired destination dropdown listing valid departments,
+  - kept the existing note-required move dialog as the final confirmation step.
+
+Commands run:
+- `npm run lint`
+
+Verification note:
+- Lint passed with no ESLint warnings/errors.
+
 ### 2026-04-09 — Order-detail follow-up: persisted Machining default + manual-only department presentation + compact timer dock
 - Fixed order part ownership initialization so newly created/converted order parts now persist the first active department immediately instead of sitting with null `currentDepartmentId`.
 - Fixed order-detail read-model behavior so a part with missing department ownership no longer appears to auto-advance to the next department when the last checklist item in the current department is checked; missing ownership now falls back only to the first active department.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,3 +1,57 @@
+## Session Handoff — 2026-04-09 (Dashboard current-department label consistency)
+
+Goal (1 sentence): Make dashboard/order summary cards stop calling active work `Unassigned` when the order-detail workflow already treats that part as belonging to the first department.
+
+### What changed
+- Updated `src/components/ShopFloorLayouts.tsx`
+  - `currentDepartmentLabelsByOrder` now falls back to the first ordered department name for non-complete orders when a part still has null `currentDepartmentId`.
+  - Completed/closed orders still skip that fallback so finished work does not get an invented active department label.
+
+### Files touched
+- `src/components/ShopFloorLayouts.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm run lint`
+
+### Verification evidence
+- Lint passed with no ESLint warnings/errors.
+
+### Next steps
+- [ ] User verify that the dashboard/order summary card now shows `Machining` (or the current first department) instead of `Unassigned` for new/received work.
+
+## Session Handoff — 2026-04-09 (Order-detail timer context link + compact submit control)
+
+Goal (1 sentence): Make the order-detail work dock tell operators exactly where another live timer is running and replace the overflowing `Submit to <Department>` label with a compact, reliable submit-destination control.
+
+### What changed
+- Updated `src/app/api/timer/active/route.ts`
+  - Enriched `activeEntries` with order/part context and an `href` for each active timer entry.
+  - Deep links now point to `/orders/{id}?part={partId}` when the timer belongs to a specific part.
+- Updated `src/app/orders/[id]/page.tsx`
+  - Added `useSearchParams()` handling so the page can preselect a part from `?part=...`.
+  - Replaced the passive `Other timer live` badge with a clickable control that opens the active timer context.
+  - Added a compact `Submit To` destination dropdown in the dock and kept the existing note-required move dialog as the actual submit confirmation path.
+
+### Files touched
+- `src/app/api/timer/active/route.ts`
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm run lint`
+
+### Verification evidence
+- Lint passed with no ESLint warnings/errors.
+
+### Next steps
+- [ ] User verify on `/orders/[id]` that clicking `Other timer live` lands on the right order/part and feels obvious enough on the floor.
+- [ ] User verify the new `Submit To` dropdown/button layout feels better with longer department names and still matches the manual move workflow.
+
 ## Session Handoff — 2026-04-08 (Unraid Docker app template refresh)
 
 Goal (1 sentence): Refresh the existing Unraid Docker app template and guide so Unraid install settings match the current ShopApp1 container requirements.

--- a/src/app/api/timer/active/route.ts
+++ b/src/app/api/timer/active/route.ts
@@ -27,6 +27,26 @@ export async function GET(req: NextRequest) {
     return NextResponse.json({ error: activeEntriesResult.error }, { status: activeEntriesResult.status });
   }
 
+  const activeEntriesWithContext = await Promise.all(
+    activeEntriesResult.data.entries.map(async (entry) => {
+      const [orderResult, partResult] = await Promise.all([
+        getOrderHeaderInfo(entry.orderId),
+        entry.partId ? getOrderPartSummary(entry.orderId, entry.partId) : Promise.resolve(null),
+      ]);
+
+      const order = orderResult.ok ? (orderResult.data as { order: unknown }).order : null;
+      const part = partResult?.ok ? (partResult.data as { part: unknown }).part : null;
+      const href = entry.partId ? `/orders/${entry.orderId}?part=${entry.partId}` : `/orders/${entry.orderId}`;
+
+      return {
+        ...entry,
+        href,
+        order,
+        part,
+      };
+    })
+  );
+
   const activeEntry = activeResult.data.entry;
   const orderResult = activeEntry ? await getOrderHeaderInfo(activeEntry.orderId) : null;
   const partResult = activeEntry?.partId
@@ -49,7 +69,7 @@ export async function GET(req: NextRequest) {
 
   return NextResponse.json({
     activeEntry,
-    activeEntries: activeEntriesResult.data.entries,
+    activeEntries: activeEntriesWithContext,
     activeOrder,
     activePart,
     totalsSeconds: totalsResult?.ok ? totalsResult.data.totalsSeconds : {},

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
 import {
   ArrowRightLeft,
   CheckCircle2,
@@ -77,6 +77,7 @@ const statusBadgeStyles: Record<string, string> = {
 
 export default function OrderDetailPage() {
   const pathname = usePathname();
+  const searchParams = useSearchParams();
   const id = pathname?.split('/').pop() ?? '';
   const toast = useToast();
   const [item, setItem] = useState<any | null>(null);
@@ -157,6 +158,7 @@ export default function OrderDetailPage() {
     note: '',
     error: null,
   });
+  const [submitToDepartmentId, setSubmitToDepartmentId] = useState('');
   const [showTimerDetails, setShowTimerDetails] = useState(false);
 
   const parts = useMemo(() => (Array.isArray(item?.parts) ? item.parts : []), [item?.parts]);
@@ -191,6 +193,11 @@ export default function OrderDetailPage() {
   );
 
   const manualMoveDepartments = useMemo(() => departments, [departments]);
+  const selectedCurrentDepartment = manualMoveDepartments.find((department) => department.id === selectedPart?.currentDepartmentId) ?? null;
+  const submitDestinationOptions = useMemo(
+    () => manualMoveDepartments.filter((department) => department.id !== selectedPart?.currentDepartmentId),
+    [manualMoveDepartments, selectedPart?.currentDepartmentId]
+  );
 
   const selectedPartDepartmentHistory = useMemo(() => {
     if (!selectedPartId) return [];
@@ -376,10 +383,15 @@ export default function OrderDetailPage() {
       setSelectedPartId(null);
       return;
     }
+    const requestedPartId = searchParams.get('part');
+    if (requestedPartId && parts.some((part: any) => part.id === requestedPartId)) {
+      setSelectedPartId((prev) => (prev === requestedPartId ? prev : requestedPartId));
+      return;
+    }
     if (!selectedPartId || !parts.some((part: any) => part.id === selectedPartId)) {
       setSelectedPartId(parts[0].id);
     }
-  }, [parts, selectedPartId]);
+  }, [parts, searchParams, selectedPartId]);
 
   useEffect(() => {
     if (!item) return;
@@ -427,6 +439,19 @@ export default function OrderDetailPage() {
 
     setSelectedTimerDepartmentId(timerDepartments[0]?.id ?? '');
   }, [selectedPart?.currentDepartmentId, selectedTimerDepartmentId, timerDepartments]);
+
+  useEffect(() => {
+    if (!submitDestinationOptions.length) {
+      setSubmitToDepartmentId('');
+      return;
+    }
+
+    if (submitToDepartmentId && submitDestinationOptions.some((department) => department.id === submitToDepartmentId)) {
+      return;
+    }
+
+    setSubmitToDepartmentId(submitDestinationOptions[0]?.id ?? '');
+  }, [submitDestinationOptions, submitToDepartmentId]);
 
   useEffect(() => {
     if (!editMode || !canEditParts) return;
@@ -553,18 +578,12 @@ export default function OrderDetailPage() {
     }
   };
 
-  const openMoveDepartmentDialog = () => {
+  const openMoveDepartmentDialog = (preferredDestinationDepartmentId?: string) => {
     if (!selectedPartId) return;
     const currentDepartmentId = selectedPart?.currentDepartmentId ?? '';
-    const currentDepartmentIndex = manualMoveDepartments.findIndex((department) => department.id === currentDepartmentId);
     const defaultDepartmentId =
-      (currentDepartmentIndex >= 0
-        ? manualMoveDepartments
-            .slice(currentDepartmentIndex + 1)
-            .find((department) => department.id !== currentDepartmentId)?.id
-        : undefined) ??
-      manualMoveDepartments.find((department) => department.id !== currentDepartmentId)?.id ??
-      manualMoveDepartments[0]?.id ??
+      preferredDestinationDepartmentId?.trim() ||
+      submitDestinationOptions[0]?.id ||
       '';
     setMoveDepartmentDialog({
       open: true,
@@ -999,8 +1018,16 @@ export default function OrderDetailPage() {
     : 0;
   const selectedPartElapsedSeconds = activeOnSelected ? selectedPartStoredSeconds + selectedActiveElapsedSeconds : selectedPartStoredSeconds;
   const hasActiveEntry = activeEntries.length > 0;
+  const activeElsewhereEntries = activeEntries.filter((entry: any) => {
+    const samePart = entry?.partId === selectedPartId;
+    const sameDepartment = !selectedTimerDepartmentId || entry?.departmentId === selectedTimerDepartmentId;
+    return !(samePart && sameDepartment);
+  });
+  const activeElsewhereEntry = activeElsewhereEntries[0] ?? null;
+  const otherActiveEntryCount = activeElsewhereEntries.length;
+  const otherTimerBadgeLabel =
+    otherActiveEntryCount > 1 ? `${otherActiveEntryCount} other timers live` : 'Other timer live';
   const startHelperLabel = 'Starts a timer on the selected part for the selected department. Department moves are manual only.';
-  const selectedCurrentDepartment = manualMoveDepartments.find((department) => department.id === selectedPart?.currentDepartmentId) ?? null;
   const selectedCurrentDepartmentIndex = selectedCurrentDepartment
     ? manualMoveDepartments.findIndex((department) => department.id === selectedCurrentDepartment.id)
     : -1;
@@ -1161,9 +1188,19 @@ export default function OrderDetailPage() {
                     {selectedPartId ? `Elapsed ${formatDuration(selectedPartElapsedSeconds)}` : 'No part selected'}
                   </div>
                 </div>
-                <Badge className={hasActiveEntry ? 'bg-emerald-500/15 text-emerald-200' : 'bg-muted text-foreground'}>
-                  {activeOnSelected ? 'Running' : hasActiveEntry ? 'Other timer live' : 'Idle'}
-                </Badge>
+                {activeOnSelected ? (
+                  <Badge className="bg-emerald-500/15 text-emerald-200">Running</Badge>
+                ) : activeElsewhereEntry?.href ? (
+                  <Button asChild size="sm" variant="ghost" className="h-7 bg-emerald-500/15 px-2 text-emerald-200 hover:bg-emerald-500/25 hover:text-emerald-100">
+                    <Link href={activeElsewhereEntry.href} title={`Open ${activeElsewhereEntry.order?.orderNumber || 'active order'}${activeElsewhereEntry.part?.partNumber ? ` / ${activeElsewhereEntry.part.partNumber}` : ''}`}>
+                      {otherTimerBadgeLabel}
+                    </Link>
+                  </Button>
+                ) : (
+                  <Badge className={hasActiveEntry ? 'bg-emerald-500/15 text-emerald-200' : 'bg-muted text-foreground'}>
+                    {hasActiveEntry ? otherTimerBadgeLabel : 'Idle'}
+                  </Badge>
+                )}
               </div>
 
               <div className="grid gap-2 sm:grid-cols-2">
@@ -1211,16 +1248,28 @@ export default function OrderDetailPage() {
                   <Square className="h-4 w-4" />
                   Stop
                 </Button>
+                <Select value={submitToDepartmentId} onValueChange={setSubmitToDepartmentId} disabled={!submitDestinationOptions.length || timerSaving || activeOnSelected}>
+                  <SelectTrigger className="h-8">
+                    <SelectValue placeholder="Submit destination" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {submitDestinationOptions.map((department) => (
+                      <SelectItem key={department.id} value={department.id}>
+                        {department.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
                 <Button
                   type="button"
                   size="sm"
                   variant="outline"
-                  disabled={!selectedPartId || timerSaving || activeOnSelected || !manualMoveDepartments.length}
-                  onClick={openMoveDepartmentDialog}
+                  disabled={!selectedPartId || timerSaving || activeOnSelected || !submitToDepartmentId}
+                  onClick={() => openMoveDepartmentDialog(submitToDepartmentId)}
                   className="justify-start gap-2"
                 >
                   <CheckCircle2 className="h-4 w-4" />
-                  {nextDepartmentOption ? `Submit to ${nextDepartmentOption.name}` : 'Move part to department'}
+                  Submit To
                 </Button>
                 <Button
                   type="button"

--- a/src/components/ShopFloorLayouts.tsx
+++ b/src/components/ShopFloorLayouts.tsx
@@ -132,6 +132,7 @@ export function ShopFloorLayouts({
     () => new Map(departments.map((department) => [department.id, department.name] as const)),
     [departments]
   );
+  const firstDepartmentName = departments[0]?.name ?? 'Unassigned';
 
   const selectedDepartmentName = departmentNameById.get(departmentId) ?? 'Unassigned';
 
@@ -187,17 +188,23 @@ export function ShopFloorLayouts({
   const currentDepartmentLabelsByOrder = useMemo(() => {
     return new Map(
       sorted.map((order) => {
+        const orderIsComplete = ['COMPLETE', 'CLOSED'].includes(String(order.status ?? '').toUpperCase());
         const labels = Array.from(
           new Set(
             (order.parts ?? [])
-              .map((part) => (part.currentDepartmentId ? departmentNameById.get(part.currentDepartmentId) ?? part.currentDepartmentId : null))
+              .map((part) => {
+                if (part.currentDepartmentId) {
+                  return departmentNameById.get(part.currentDepartmentId) ?? part.currentDepartmentId;
+                }
+                return orderIsComplete ? null : firstDepartmentName;
+              })
               .filter((value): value is string => Boolean(value))
           )
         );
         return [order.id, labels] as const;
       })
     );
-  }, [departmentNameById, sorted]);
+  }, [departmentNameById, firstDepartmentName, sorted]);
 
   const handleSortChange = (column: (typeof SORT_KEYS)[number]) => {
     setSortKey((prev) => {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,6 +3,52 @@
 ## Session Metadata
 - Date: 2026-04-09
 - Agent: Codex GPT-5
+- Task ID: Order detail timer-link + compact submit destination control
+- Goal: Make the order-detail work dock identify where an already-running timer lives and replace the long `Submit to <Department>` button copy with a compact `Submit To` flow that fits reliably.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated current gap in `src/app/orders/[id]/page.tsx`: the dock only showed a passive `Other timer live` badge with no destination context, and long department names overflowed the manual-submit control.
+
+## Plan First
+- [x] Add an exact active-timer destination link so `Other timer live` opens the active order/part context.
+- [x] Add a compact submit-destination dropdown in the work dock and keep the required note inside the existing move dialog.
+- [x] Keep the current manual-only move rules intact and run relevant verification.
+- [x] Update continuity docs with outcomes and evidence.
+
+## Verification Checklist
+- [x] `npm run lint`
+
+## Review + Results
+- The work dock now turns `Other timer live` into a clickable control that opens the active timer's order and preselects the exact part when available.
+- `/api/timer/active` now returns active-entry context links/order-part summaries so the order detail page can route operators to the right timer instead of a vague status badge.
+- The long `Submit to <Department>` label was replaced by a compact dock flow: destination dropdown plus `Submit To` button, while the existing move dialog still enforces the required note before moving a part.
+
+## Session Metadata
+- Date: 2026-04-09
+- Agent: Codex GPT-5
+- Task ID: Dashboard current-department label consistency follow-up
+- Goal: Stop dashboard/order summary cards from showing `Unassigned` for active parts that the workflow already treats as the first department.
+
+## Dependency Validation
+- [x] Reviewed the existing 2026-04-09 timer/department follow-up notes and confirmed the mismatch was display-only in the dashboard/layout card path.
+- [x] Validated that order-detail/manual-move logic already applies first-department fallback, while `ShopFloorLayouts` still rendered raw null `currentDepartmentId` as `Unassigned`.
+
+## Plan First
+- [x] Update dashboard current-department label shaping to use the same first-department fallback for non-complete orders.
+- [x] Keep completed/closed orders from being mislabeled with a fallback department.
+- [x] Run verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npm run lint`
+
+## Review + Results
+- Dashboard/grid digest current-department labels now fall back to the first ordered department for active orders whose parts still have null stored `currentDepartmentId`.
+- Completed/closed orders still avoid that fallback, so the card no longer contradicts the manual-move flow for active work while preserving end-state behavior.
+
+## Session Metadata
+- Date: 2026-04-09
+- Agent: Codex GPT-5
 - Task ID: Order detail department default + timer density + manual-only progression
 - Goal: Make converted/new orders default parts to Machining/first department, stop any apparent checklist-driven auto department progression, and redesign the order-detail timer area so parts stay spatially primary.
 


### PR DESCRIPTION
## What changed
- turned the order work-dock `Other timer live` status into a direct link to the active order/part context
- added active-timer context data to `/api/timer/active` and taught `/orders/[id]` to honor `?part=` deep links
- replaced the overflowing `Submit to <Department>` work-dock button copy with a compact `Submit To` flow using a destination dropdown plus the existing note-required move dialog
- fixed dashboard/grid digest current-department labels so active work no longer shows `Unassigned` when the workflow already treats it as the first department
- updated continuity artifacts for the session

## Why
Operators were getting two kinds of conflicting signals:
- the dock said another timer was running but gave no clue where
- some screens said a part was `Unassigned` even though moving it to Machining was rejected because the workflow already treated Machining as the current department

This PR makes those cues explicit and consistent without changing the manual-only department move rules.

## Impact
- shop-floor users can jump directly to the active timer context
- long department names no longer overflow the submit control in the work dock
- dashboard/order summary department labels now match the actual order-detail workflow behavior for active work

## Validation
- `npm run lint`

## Notes
- unrelated local changes in `.env`, `.env.example`, and `prisma/prisma/` were intentionally left out of this PR
- local `gh auth status` is currently stale in this workspace, so the PR was created through the GitHub connector path instead of the CLI