### PR TITLE
[codex] Clean up order submit dialog workflow

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -197,6 +197,28 @@ Agents MUST update this at the end of every session.
 
 ## Session Log (append newest at top)
 
+### 2026-04-09 — Order-detail submit dialog follow-up: confirm button now tracks selected destination
+- Fixed `src/app/orders/[id]/page.tsx` so the dialog confirm button label now derives from the actual selected destination department instead of the stale `nextDepartmentOption` helper.
+- This removes the mismatch where the dropdown could say `Shipping` while the button still said `Submit to Fab`.
+- Added a prevention rule to `tasks/lessons.md` covering live-selection labels in dialogs/forms.
+
+Commands run:
+- `npm run lint`
+
+Verification note:
+- Lint passed with no ESLint warnings/errors.
+
+### 2026-04-09 — Order-detail submit flow cleanup: dialog owns destination selection
+- Removed the redundant submit-destination dropdown from the `/orders/[id]` work dock so operators now use a single `Submit To` button to open the move dialog.
+- Kept destination selection inside the dialog only, where the current department is shown first and the destination list now excludes the current department.
+- Preserved the existing required move-note/manual-submit workflow while simplifying the operator path.
+
+Commands run:
+- `npm run lint`
+
+Verification note:
+- Lint passed with no ESLint warnings/errors.
+
 ### 2026-04-09 — Dashboard follow-up: current department card no longer says `Unassigned` for active fallback-owned work
 - Fixed `src/components/ShopFloorLayouts.tsx` so dashboard/grid-digest current-department labels now use the same first-department fallback as the order-detail workflow for non-complete orders.
 - This removes the contradiction where a part could be treated as Machining in move/timer flows but still render as `Unassigned` on the summary card.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,3 +1,56 @@
+## Session Handoff — 2026-04-09 (Order-detail submit dialog label correction)
+
+Goal (1 sentence): Make the move-dialog confirm button always reflect the destination department the operator actually selected.
+
+### What changed
+- Updated `src/app/orders/[id]/page.tsx`
+  - Replaced the dialog confirm-button label source so it now reads from `moveDepartmentDialog.destinationDepartmentId`.
+  - The button copy now updates live with the dialog selection (`Submit to Shipping`, etc.) instead of staying tied to the default next-department helper.
+- Updated `tasks/lessons.md`
+  - Added a prevention rule covering stale action labels in selection-driven dialogs/forms.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/lessons.md`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm run lint`
+
+### Verification evidence
+- Lint passed with no ESLint warnings/errors.
+
+### Next steps
+- [ ] User verify on `/orders/[id]` that changing the dialog destination immediately updates the confirm button label to the same department.
+
+## Session Handoff — 2026-04-09 (Order-detail submit dialog cleanup)
+
+Goal (1 sentence): Remove the redundant submit destination control from the order-detail dock so `Submit To` opens a single dialog that clearly shows the current department and lets the operator choose the destination there.
+
+### What changed
+- Updated `src/app/orders/[id]/page.tsx`
+  - Removed the dock-level submit destination dropdown and its extra local state.
+  - `Submit To` now opens the move dialog directly.
+  - The dialog now shows the current department in a dedicated summary block at the top.
+  - The dialog destination list now contains only valid non-current departments, so operators are not asked to pick the same department twice.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm run lint`
+
+### Verification evidence
+- Lint passed with no ESLint warnings/errors.
+
+### Next steps
+- [ ] User verify on `/orders/[id]` that `Submit To` now feels cleaner: one button in the dock, current department shown at top of the dialog, destination chosen only inside the dialog.
+
 ## Session Handoff — 2026-04-09 (Dashboard current-department label consistency)
 
 Goal (1 sentence): Make dashboard/order summary cards stop calling active work `Unassigned` when the order-detail workflow already treats that part as belonging to the first department.

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -158,7 +158,6 @@ export default function OrderDetailPage() {
     note: '',
     error: null,
   });
-  const [submitToDepartmentId, setSubmitToDepartmentId] = useState('');
   const [showTimerDetails, setShowTimerDetails] = useState(false);
 
   const parts = useMemo(() => (Array.isArray(item?.parts) ? item.parts : []), [item?.parts]);
@@ -441,19 +440,6 @@ export default function OrderDetailPage() {
   }, [selectedPart?.currentDepartmentId, selectedTimerDepartmentId, timerDepartments]);
 
   useEffect(() => {
-    if (!submitDestinationOptions.length) {
-      setSubmitToDepartmentId('');
-      return;
-    }
-
-    if (submitToDepartmentId && submitDestinationOptions.some((department) => department.id === submitToDepartmentId)) {
-      return;
-    }
-
-    setSubmitToDepartmentId(submitDestinationOptions[0]?.id ?? '');
-  }, [submitDestinationOptions, submitToDepartmentId]);
-
-  useEffect(() => {
     if (!editMode || !canEditParts) return;
 
     const loadOptions = async () => {
@@ -578,11 +564,10 @@ export default function OrderDetailPage() {
     }
   };
 
-  const openMoveDepartmentDialog = (preferredDestinationDepartmentId?: string) => {
+  const openMoveDepartmentDialog = () => {
     if (!selectedPartId) return;
-    const currentDepartmentId = selectedPart?.currentDepartmentId ?? '';
     const defaultDepartmentId =
-      preferredDestinationDepartmentId?.trim() ||
+      nextDepartmentOption?.id ||
       submitDestinationOptions[0]?.id ||
       '';
     setMoveDepartmentDialog({
@@ -1035,7 +1020,12 @@ export default function OrderDetailPage() {
     selectedCurrentDepartmentIndex >= 0
       ? manualMoveDepartments[selectedCurrentDepartmentIndex + 1] ?? null
       : manualMoveDepartments[0] ?? null;
-  const moveActionLabel = nextDepartmentOption ? `Submit to ${nextDepartmentOption.name}` : 'Move part to department';
+  const selectedMoveDestination = submitDestinationOptions.find(
+    (department) => department.id === moveDepartmentDialog.destinationDepartmentId
+  ) ?? null;
+  const moveActionLabel = selectedMoveDestination
+    ? `Submit to ${selectedMoveDestination.name}`
+    : 'Move part to department';
   const canMarkPartComplete = (selectedCurrentDepartment?.name ?? '').trim().toLowerCase() === 'shipping';
 
   return (
@@ -1098,13 +1088,11 @@ export default function OrderDetailPage() {
             <DialogTitle>Move part to department</DialogTitle>
           </DialogHeader>
           <div className="space-y-4">
-            <div className="text-sm text-muted-foreground">
-              Current department:{' '}
-              <span className="font-medium text-foreground">
-                {manualMoveDepartments.find((department) => department.id === selectedPart?.currentDepartmentId)?.name ??
-                  selectedPart?.currentDepartmentId ??
-                  'Unassigned'}
-              </span>
+            <div className="rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-sm">
+              <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Current department</div>
+              <div className="mt-1 font-semibold text-foreground">
+                {selectedCurrentDepartment?.name ?? selectedPart?.currentDepartmentId ?? 'Unassigned'}
+              </div>
             </div>
             <div className="grid gap-2">
               <Label htmlFor="move-department-select">Destination department</Label>
@@ -1122,7 +1110,7 @@ export default function OrderDetailPage() {
                   <SelectValue placeholder="Choose destination department" />
                 </SelectTrigger>
                 <SelectContent>
-                  {manualMoveDepartments.map((department) => (
+                  {submitDestinationOptions.map((department) => (
                     <SelectItem key={department.id} value={department.id}>
                       {department.name}
                     </SelectItem>
@@ -1248,24 +1236,12 @@ export default function OrderDetailPage() {
                   <Square className="h-4 w-4" />
                   Stop
                 </Button>
-                <Select value={submitToDepartmentId} onValueChange={setSubmitToDepartmentId} disabled={!submitDestinationOptions.length || timerSaving || activeOnSelected}>
-                  <SelectTrigger className="h-8">
-                    <SelectValue placeholder="Submit destination" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {submitDestinationOptions.map((department) => (
-                      <SelectItem key={department.id} value={department.id}>
-                        {department.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
                 <Button
                   type="button"
                   size="sm"
                   variant="outline"
-                  disabled={!selectedPartId || timerSaving || activeOnSelected || !submitToDepartmentId}
-                  onClick={() => openMoveDepartmentDialog(submitToDepartmentId)}
+                  disabled={!selectedPartId || timerSaving || activeOnSelected || !submitDestinationOptions.length}
+                  onClick={openMoveDepartmentDialog}
                   className="justify-start gap-2"
                 >
                   <CheckCircle2 className="h-4 w-4" />

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,3 +1,9 @@
+## 2026-04-09 — UI action labels must follow active selection state
+- Trigger: User caught the move dialog showing `Submit to Fab` while the selected destination was `Shipping`.
+- Mistake pattern: I left the confirm-button label bound to a derived default/next-step value instead of the dialog's actual selected destination state.
+- Preventive rule: For dialogs and forms with mutable selections, audit every visible action label against the live controlled value before closing the task; never leave confirm copy tied to an initialization default.
+- Applied in next session where: 2026-04-09 order-detail submit dialog label fix.
+
 ## 2026-03-19 — SQLite migration default-value trap
 - Trigger: Prisma migrate failed while adding timestamp columns with `DEFAULT CURRENT_TIMESTAMP` via `ALTER TABLE` on SQLite.
 - Mistake pattern: I assumed SQLite could add non-null timestamp columns with non-constant defaults directly.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -3,6 +3,52 @@
 ## Session Metadata
 - Date: 2026-04-09
 - Agent: Codex GPT-5
+- Task ID: Order detail submit-dialog cleanup
+- Goal: Remove the redundant submit-destination dropdown from the order-detail dock so `Submit To` opens the dialog and the dialog alone owns destination selection.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current issue in `src/app/orders/[id]/page.tsx`: the dock had a destination dropdown plus a second destination selector in the dialog, which duplicated state and made the flow feel broken/redundant.
+
+## Plan First
+- [x] Remove the dock-level destination selector and its state from `/orders/[id]`.
+- [x] Keep `Submit To` as the single trigger and let the dialog own the destination picker plus required note.
+- [x] Keep current department visible at the top of the dialog and limit destination choices to valid non-current departments.
+- [x] Run relevant verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npm run lint`
+
+## Review + Results
+- The left-side dock now shows only the `Submit To` action; the redundant destination dropdown beside it is gone.
+- Clicking `Submit To` now opens the move dialog directly, with the current department surfaced in a dedicated summary block at the top.
+- Destination choice now lives only inside the dialog, and the list excludes the current department so the operator only sees valid targets.
+
+## Session Metadata
+- Date: 2026-04-09
+- Agent: Codex GPT-5
+- Task ID: Order detail submit-dialog label correction
+- Goal: Make the dialog confirm button always reflect the department actually selected in the destination dropdown.
+
+## Dependency Validation
+- [x] Reviewed the just-shipped submit-dialog cleanup and reproduced the remaining gap in `src/app/orders/[id]/page.tsx`: the button label still read from the old `nextDepartmentOption` helper instead of dialog selection state.
+- [x] Logged a prevention rule in `tasks/lessons.md` per workflow requirements after the user correction.
+
+## Plan First
+- [x] Replace the dialog confirm-label source so it derives from `moveDepartmentDialog.destinationDepartmentId`.
+- [x] Keep the rest of the move flow unchanged and re-run verification.
+- [x] Update continuity docs with the correction and evidence.
+
+## Verification Checklist
+- [x] `npm run lint`
+
+## Review + Results
+- The dialog confirm button now follows the currently selected destination department instead of the stale next-department default.
+- Selecting `Shipping` now yields `Submit to Shipping`; selecting another department updates the button label accordingly.
+
+## Session Metadata
+- Date: 2026-04-09
+- Agent: Codex GPT-5
 - Task ID: Order detail timer-link + compact submit destination control
 - Goal: Make the order-detail work dock identify where an already-running timer lives and replace the long `Submit to <Department>` button copy with a compact `Submit To` flow that fits reliably.
 


### PR DESCRIPTION
## What changed
- removed the redundant submit-destination dropdown from the order-detail work dock
- made `Submit To` open the move dialog directly and show the current department at the top
- limited dialog destination choices to valid non-current departments
- fixed the confirm button label so it always matches the department currently selected in the dialog
- recorded the continuity updates and the follow-up prevention rule for stale selection-driven labels

## Why
The previous flow duplicated destination selection in two places and still let the confirm button drift from the actual chosen destination. That made the workflow feel unreliable and caused the exact Fab vs Shipping mismatch the user reported.

## Impact
Operators now have one clear submit path: click `Submit To`, choose the destination in the dialog, add the move note, and submit with a button label that matches the selected department.

## Validation
- `npm run lint`