### PR TITLE
[codex] Add BOM analyzer PDF upload support

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1680,3 +1680,21 @@ Commands run:
 
 Verification note:
 - Lint passed with no ESLint warnings/errors.
+### 2026-04-09 — BOM analyzer PDF upload support
+- Added PDF support to the BOM analyzer upload surfaces:
+  - `/orders/[id]` BOM tab now accepts `application/pdf` in the file picker,
+  - stored `PRINT` attachments with `application/pdf` now appear in the BOM analyzer attachment picker,
+  - `/private/print-analyzer` now accepts PDF uploads too.
+- Reworked `POST /api/print-analyzer/analyze` so it now accepts `data:application/pdf` payloads, rasterizes page 1 to PNG with `pdfjs-dist` + `@napi-rs/canvas`, and then runs the existing image-based OpenAI vision flow unchanged after that conversion step.
+- Added Decision Log entry documenting the new PDF-rendering dependency choice and updated `docs/PRINT_ANALYZER.md` to describe first-page PDF behavior.
+
+Commands run:
+- `npm install pdfjs-dist @napi-rs/canvas`
+- `npm run lint`
+- `npm run build`
+- `node -` (runtime PDF rasterization sanity check against stored PDF `storage/sterling-tool-and-die/s-k-industrial/std-1007/tdc-british-standard-pipe-threads-1-d367a7f6-608a-47c9-8cea-274c3f180503.pdf`)
+
+Verification note:
+- Lint passed with no ESLint warnings/errors.
+- Runtime PDF rasterization check succeeded: `pdf-render-ok:303905:1224x1584`.
+- `npm run build` still fails in this environment because of the existing `next/font` Roboto fetch / `127.0.0.1:9` connection issue, but the PDF-renderer native-module webpack parse error is resolved.

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -60,6 +60,10 @@ Goal: a scalable foundation that can grow.
 
 ## Decision Log (append newest at top)
 
+### 2026-04-09 — BOM analyzer PDF support uses pdf.js page-1 rasterization before vision
+Decision: Add `pdfjs-dist` and `@napi-rs/canvas` and rasterize the first page of uploaded/stored PDFs to PNG server-side before sending the result through the existing print-analyzer vision flow.
+Reason: The BOM analyzer is image-based and the existing `sharp` build in this environment cannot rasterize PDFs, so PDF support requires a dedicated renderer without introducing external system-binary dependencies.
+
 ### 2026-04-09 — Missing part department ownership must default to first department, never inferred next-step routing
 Decision: When an order part has no persisted `currentDepartmentId`, read models and initialization/backfill paths must assign the first active department in ordering (currently Machining) instead of inferring ownership from whichever checklist department still has open items.
 Reason: Inferring department from checklist state makes last-item completion look like an automatic department move, which conflicts with the manual-submit workflow and obscures true ownership after quote conversion or other uninitialized-part paths.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -2827,3 +2827,53 @@ Goal (1 sentence): Make converted/new orders default part ownership to Machining
 - [ ] User verify on `/orders/[id]` that converted parts now land in Machining/current first department instead of showing `Unassigned`.
 - [ ] User verify that checking the last checklist item no longer makes the part appear to auto-move departments before using the manual submit/move action.
 - [ ] Optional follow-up: if the owner wants an even more aggressive left-rail reduction, split timer controls and part list into separate stacked cards on mobile/tablet breakpoints only.
+## Session Handoff — 2026-04-09 (BOM analyzer PDF upload support)
+
+Goal (1 sentence): Let the BOM analyzer accept PDFs by rasterizing page 1 to an image before running the existing analyzer flow.
+
+### What changed
+- Updated `src/app/orders/[id]/PartBomTab.tsx`
+  - BOM upload input now accepts `image/*,application/pdf`.
+  - Stored attachment picker now includes PDF print attachments instead of filtering them out as unsupported non-images.
+  - Attachment-loading copy/errors now refer to supported print files rather than image-only files.
+- Updated `src/app/private/print-analyzer/page.tsx`
+  - Private analyzer upload input now accepts `image/*,application/pdf`.
+  - Page copy now explicitly says image or PDF.
+- Updated `src/app/api/print-analyzer/analyze/route.ts`
+  - Route now accepts `data:application/pdf`.
+  - Added server-side PDF page-1 rasterization using `pdfjs-dist` + `@napi-rs/canvas`.
+  - Existing OpenAI/sharp image-analysis pipeline remains unchanged after PDF-to-PNG conversion.
+- Updated `docs/PRINT_ANALYZER.md`
+  - Documented PDF support and clarified that current behavior analyzes the first page.
+- Updated `docs/AGENT_CONTEXT.md`
+  - Added Decision Log entry for the new PDF-rendering dependency choice.
+- Installed dependencies
+  - `pdfjs-dist`
+  - `@napi-rs/canvas`
+
+### Files touched
+- `package.json`
+- `package-lock.json`
+- `src/app/orders/[id]/PartBomTab.tsx`
+- `src/app/private/print-analyzer/page.tsx`
+- `src/app/api/print-analyzer/analyze/route.ts`
+- `docs/PRINT_ANALYZER.md`
+- `docs/AGENT_CONTEXT.md`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm install pdfjs-dist @napi-rs/canvas`
+- `npm run lint`
+- `npm run build`
+- `node -` (runtime PDF rasterization sanity check against `storage/sterling-tool-and-die/s-k-industrial/std-1007/tdc-british-standard-pipe-threads-1-d367a7f6-608a-47c9-8cea-274c3f180503.pdf`)
+
+### Verification evidence
+- Lint passed with no ESLint warnings/errors.
+- Runtime PDF rasterization succeeded with `pdfjs-dist` + `@napi-rs/canvas`: `pdf-render-ok:303905:1224x1584`.
+- `npm run build` still fails in this environment due the existing `next/font` Roboto fetch / `127.0.0.1:9` connection issue, but the PDF-renderer native-module webpack parse failure introduced during this work is gone.
+
+### Next steps
+- [ ] User verify on `/orders/[id]` BOM tab that uploading a PDF or selecting a stored PDF print attachment now analyzes successfully.
+- [ ] Optional follow-up: expose page-selection for multi-page PDFs if the shop starts uploading packet-style prints.

--- a/docs/PRINT_ANALYZER.md
+++ b/docs/PRINT_ANALYZER.md
@@ -1,7 +1,7 @@
 # Print Analyzer
 
 ## Purpose
-The Print Analyzer is an isolated internal page for extracting structured manufacturing-print data from an uploaded image using OpenAI vision analysis.
+The Print Analyzer is an isolated internal page for extracting structured manufacturing-print data from an uploaded image or PDF using OpenAI vision analysis.
 
 ## Route paths
 - UI: `/private/print-analyzer`
@@ -37,9 +37,14 @@ The Print Analyzer is an isolated internal page for extracting structured manufa
 ## How to use
 1. Start the app.
 2. Navigate directly to `/private/print-analyzer`.
-3. Upload a print image (`PNG`, `JPG`, `WEBP`, or any `image/*` MIME type).
+3. Upload a print image (`PNG`, `JPG`, `WEBP`, or any `image/*` MIME type) or a `PDF`.
 4. Click **Analyze**.
 5. Review extracted units, tolerances, setup/flips analysis, holes/radii/tapped-hole tables, warnings, and raw JSON.
+
+## PDF behavior
+- PDFs are rasterized server-side before analysis.
+- Current behavior uses the first page only.
+- Very large or low-resolution PDFs may still produce weak OCR results after rasterization.
 
 ## Known limitations
 - Blurry, low-resolution, skewed, or partially cropped prints reduce extraction quality.

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "shop-orders-auth",
       "hasInstallScript": true,
       "dependencies": {
+        "@napi-rs/canvas": "^0.1.97",
         "@prisma/client": "^5.18.0",
         "@radix-ui/react-alert-dialog": "^1.0.4",
         "@radix-ui/react-avatar": "^1.0.4",
@@ -26,6 +27,7 @@
         "next": "^15.5.7",
         "next-auth": "^4.24.7",
         "openai": "^6.25.0",
+        "pdfjs-dist": "^5.6.205",
         "react": "18.3.1",
         "react-dom": "18.3.1",
         "sharp": "^0.33.5",
@@ -1226,6 +1228,255 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas/-/canvas-0.1.97.tgz",
+      "integrity": "sha512-8cFniXvrIEnVwuNSRCW9wirRZbHvrD3JVujdS2P5n5xiJZNZMOZcfOvJ1pb66c7jXMKHHglJEDVJGbm8XWFcXQ==",
+      "license": "MIT",
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-arm64": "0.1.97",
+        "@napi-rs/canvas-darwin-x64": "0.1.97",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.97",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.97",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.97",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.97",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.97"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.97.tgz",
+      "integrity": "sha512-V1c/WVw+NzH8vk7ZK/O8/nyBSCQimU8sfMsB/9qeSvdkGKNU7+mxy/bIF0gTgeBFmHpj30S4E9WHMSrxXGQuVQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.97.tgz",
+      "integrity": "sha512-ok+SCEF4YejcxuJ9Rm+WWunHHpf2HmiPxfz6z1a/NFQECGXtsY7A4B8XocK1LmT1D7P174MzwPF9Wy3AUAwEPw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.97.tgz",
+      "integrity": "sha512-PUP6e6/UGlclUvAQNnuXCcnkpdUou6VYZfQOQxExLp86epOylmiwLkqXIvpFmjoTEDmPmXrI+coL/9EFU1gKPA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.97.tgz",
+      "integrity": "sha512-XyXH2L/cic8eTNtbrXCcvqHtMX/nEOxN18+7rMrAM2XtLYC/EB5s0wnO1FsLMWmK+04ZSLN9FBGipo7kpIkcOw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Kuq/M3djq0K8ktgz6nPlK7Ne5d4uWeDxPpyKWOjWDK2RIOhHVtLtyLiJw2fuldw7Vn4mhw05EZXCEr4Q76rs9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.97.tgz",
+      "integrity": "sha512-kKmSkQVnWeqg7qdsiXvYxKhAFuHz3tkBjW/zyQv5YKUPhotpaVhpBGv5LqCngzyuRV85SXoe+OFj+Tv0a0QXkQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.97.tgz",
+      "integrity": "sha512-Jc7I3A51jnEOIAXeLsN/M/+Z28LUeakcsXs07FLq9prXc0eYOtVwsDEv913Gr+06IRo34gJJVgT0TXvmz+N2VA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.97.tgz",
+      "integrity": "sha512-iDUBe7AilfuBSRbSa8/IGX38Mf+iCSBqoVKLSQ5XaY2JLOaqz1TVyPFEyIck7wT6mRQhQt5sN6ogfjIDfi74tg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.97.tgz",
+      "integrity": "sha512-AKLFd/v0Z5fvgqBDqhvqtAdx+fHMJ5t9JcUNKq4FIZ5WH+iegGm8HPdj00NFlCSnm83Fp3Ln8I2f7uq1aIiWaA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.97.tgz",
+      "integrity": "sha512-u883Yr6A6fO7Vpsy9YE4FVCIxzzo5sO+7pIUjjoDLjS3vQaNMkVzx5bdIpEL+ob+gU88WDK4VcxYMZ6nmnoX9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.97",
+      "resolved": "https://registry.npmjs.org/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.97.tgz",
+      "integrity": "sha512-sWtD2EE3fV0IzN+iiQUqr/Q1SwqWhs2O1FKItFlxtdDkikpEj5g7DKQpY3x55H/MAOnL8iomnlk3mcEeGiUMoQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {
@@ -7295,6 +7546,13 @@
         "@img/sharp-win32-x64": "0.34.5"
       }
     },
+    "node_modules/node-readable-to-web-readable-stream": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/node-readable-to-web-readable-stream/-/node-readable-to-web-readable-stream-0.4.2.tgz",
+      "integrity": "sha512-/cMZNI34v//jUTrI+UIo4ieHAB5EZRY/+7OmXZgBxaWBMcW2tGdceIw06RFxWxrKZ5Jp3sI2i5TsRo+CBhtVLQ==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/node-releases": {
       "version": "2.0.21",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
@@ -7679,6 +7937,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "5.6.205",
+      "resolved": "https://registry.npmjs.org/pdfjs-dist/-/pdfjs-dist-5.6.205.tgz",
+      "integrity": "sha512-tlUj+2IDa7G1SbvBNN74UHRLJybZDWYom+k6p5KIZl7huBvsA4APi6mKL+zCxd3tLjN5hOOEE9Tv7VdzO88pfg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.19.0 || >=22.13.0 || >=24"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.96",
+        "node-readable-to-web-readable-stream": "^0.4.2"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "postinstall": "node scripts/check-path-casing.js && node scripts/init-storage.cjs && node scripts/setup-db.cjs"
   },
   "dependencies": {
+    "@napi-rs/canvas": "^0.1.97",
     "@prisma/client": "^5.18.0",
     "@radix-ui/react-alert-dialog": "^1.0.4",
     "@radix-ui/react-avatar": "^1.0.4",
@@ -42,6 +43,7 @@
     "next": "^15.5.7",
     "next-auth": "^4.24.7",
     "openai": "^6.25.0",
+    "pdfjs-dist": "^5.6.205",
     "react": "18.3.1",
     "react-dom": "18.3.1",
     "sharp": "^0.33.5",

--- a/src/app/api/print-analyzer/analyze/route.ts
+++ b/src/app/api/print-analyzer/analyze/route.ts
@@ -1,3 +1,6 @@
+import { createRequire } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
 import OpenAI from 'openai';
 import sharp from 'sharp';
 import { NextResponse } from 'next/server';
@@ -20,6 +23,18 @@ const TITLE_BLOCK_CONFIDENCE_THRESHOLD = 0.55;
 const PASS_ONE_MODEL = 'gpt-4.1-mini';
 const PASS_TWO_MODEL = 'gpt-4.1-mini';
 const PAPER_PRINT_MESSAGE = 'Unable to confidently read general tolerances. Please check the paper print.';
+const PDF_RENDER_SCALE = 2;
+const CANVAS_MODULE_NAME = ['@napi-rs', 'canvas'].join('/');
+
+const require = createRequire(import.meta.url);
+const loadCanvasModule = () => require(CANVAS_MODULE_NAME) as {
+  createCanvas: (width: number, height: number) => {
+    width: number;
+    height: number;
+    getContext: (contextId: '2d') => unknown;
+    encode: (format: 'png') => Promise<Uint8Array>;
+  };
+};
 
 type ModelPayload = {
   rawText: string;
@@ -41,10 +56,10 @@ function extractJsonText(raw: string): string {
   return objectSlice || trimmed;
 }
 
-function decodeImageDataUrl(dataUrl: string): { buffer: Buffer; mimeType: string } {
-  const match = dataUrl.match(/^data:(image\/[a-zA-Z0-9.+-]+);base64,(.+)$/);
+function decodeDataUrl(dataUrl: string): { buffer: Buffer; mimeType: string } {
+  const match = dataUrl.match(/^data:([a-zA-Z0-9.+/-]+);base64,(.+)$/);
   if (!match) {
-    throw new Error('Invalid image data URL payload.');
+    throw new Error('Invalid file data URL payload.');
   }
 
   const [, mimeType, base64Data] = match;
@@ -56,6 +71,128 @@ function decodeImageDataUrl(dataUrl: string): { buffer: Buffer; mimeType: string
 
 function toDataUrl(buffer: Buffer, mimeType: string): string {
   return `data:${mimeType};base64,${buffer.toString('base64')}`;
+}
+
+function isPdfMimeType(mimeType: string): boolean {
+  return mimeType === 'application/pdf';
+}
+
+type PdfJsModule = {
+  getDocument: (src: {
+    data: Uint8Array;
+    useWorkerFetch: boolean;
+    isEvalSupported: boolean;
+  }) => { promise: Promise<PdfDocumentProxy>; destroy: () => Promise<void> };
+};
+
+type PdfDocumentProxy = {
+  getPage: (pageNumber: number) => Promise<PdfPageProxy>;
+  cleanup: () => Promise<void>;
+};
+
+type PdfPageProxy = {
+  getViewport: (params: { scale: number }) => { width: number; height: number };
+  render: (params: {
+    canvasContext: unknown;
+    viewport: { width: number; height: number };
+    canvasFactory: PdfCanvasFactory;
+  }) => { promise: Promise<void> };
+  cleanup: () => void;
+};
+
+class PdfCanvasFactory {
+  create(width: number, height: number) {
+    if (width <= 0 || height <= 0) {
+      throw new Error('Invalid canvas size');
+    }
+
+    const { createCanvas } = loadCanvasModule();
+    const canvas = createCanvas(Math.ceil(width), Math.ceil(height));
+    return {
+      canvas,
+      context: canvas.getContext('2d'),
+    };
+  }
+
+  reset(target: { canvas: ReturnType<ReturnType<typeof loadCanvasModule>['createCanvas']> }, width: number, height: number) {
+    target.canvas.width = Math.ceil(width);
+    target.canvas.height = Math.ceil(height);
+  }
+
+  destroy(target: { canvas: ReturnType<ReturnType<typeof loadCanvasModule>['createCanvas']> | null; context: unknown | null }) {
+    if (!target.canvas) return;
+
+    target.canvas.width = 0;
+    target.canvas.height = 0;
+    target.canvas = null;
+    target.context = null;
+  }
+}
+
+async function loadPdfJs(): Promise<PdfJsModule> {
+  const pdfJsPath = require.resolve('pdfjs-dist/legacy/build/pdf.mjs');
+  return (await import(pathToFileURL(pdfJsPath).href)) as PdfJsModule;
+}
+
+async function rasterizePdfFirstPage(buffer: Buffer): Promise<Buffer> {
+  const pdfjs = await loadPdfJs();
+  const loadingTask = pdfjs.getDocument({
+    data: new Uint8Array(buffer),
+    useWorkerFetch: false,
+    isEvalSupported: false,
+  });
+
+  try {
+    const pdfDocument = await loadingTask.promise;
+
+    try {
+      const page = await pdfDocument.getPage(1);
+
+      try {
+        const viewport = page.getViewport({ scale: PDF_RENDER_SCALE });
+        const canvasFactory = new PdfCanvasFactory();
+        const canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
+
+        try {
+          await page.render({
+            canvasContext: canvasAndContext.context,
+            viewport,
+            canvasFactory,
+          }).promise;
+
+          return Buffer.from(await canvasAndContext.canvas.encode('png'));
+        } finally {
+          canvasFactory.destroy(canvasAndContext);
+        }
+      } finally {
+        page.cleanup();
+      }
+    } finally {
+      await pdfDocument.cleanup();
+    }
+  } finally {
+    await loadingTask.destroy();
+  }
+}
+
+async function normalizeUploadToImageDataUrl(dataUrl: string): Promise<string> {
+  const { buffer, mimeType } = decodeDataUrl(dataUrl);
+
+  if (mimeType.startsWith('image/')) {
+    return toDataUrl(buffer, mimeType);
+  }
+
+  if (!isPdfMimeType(mimeType)) {
+    throw new Error('Unsupported upload type. Use an image or PDF file.');
+  }
+
+  try {
+    const rasterizedPdf = await rasterizePdfFirstPage(buffer);
+    return toDataUrl(rasterizedPdf, 'image/png');
+  } catch (error) {
+    const message = error instanceof Error ? collapseWhitespace(error.message) : 'Unknown PDF conversion error';
+    throw new Error(`Failed to convert PDF to image. ${message}`);
+  }
 }
 
 function uniqueWarnings(...warningSets: string[][]): string[] {
@@ -293,8 +430,14 @@ export async function POST(req: Request) {
     | null;
   const dataUrl = body?.dataUrl;
 
-  if (typeof dataUrl !== 'string' || !dataUrl.startsWith('data:image/')) {
-    return NextResponse.json({ error: 'Invalid request body. Expected { dataUrl: "data:image/..." }.' }, { status: 400 });
+  if (
+    typeof dataUrl !== 'string' ||
+    (!dataUrl.startsWith('data:image/') && !dataUrl.startsWith('data:application/pdf'))
+  ) {
+    return NextResponse.json(
+      { error: 'Invalid request body. Expected { dataUrl: "data:image/..." } or { dataUrl: "data:application/pdf;..." }.' },
+      { status: 400 }
+    );
   }
 
   if (!process.env.OPENAI_API_KEY) {
@@ -304,8 +447,8 @@ export async function POST(req: Request) {
   const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
   try {
-    const { buffer: imageBuffer, mimeType } = decodeImageDataUrl(dataUrl);
-    const sanitizedFullImageDataUrl = toDataUrl(imageBuffer, mimeType);
+    const sanitizedFullImageDataUrl = await normalizeUploadToImageDataUrl(dataUrl);
+    const { buffer: imageBuffer } = decodeDataUrl(sanitizedFullImageDataUrl);
 
     const passOneResult = await runVisionPass({
       openai,

--- a/src/app/orders/[id]/PartBomTab.tsx
+++ b/src/app/orders/[id]/PartBomTab.tsx
@@ -108,6 +108,10 @@ async function fileToDataUrl(file: File): Promise<string> {
   });
 }
 
+function isPdfMimeType(mimeType: string): boolean {
+  return mimeType === 'application/pdf';
+}
+
 function isAnalyzeErrorPayload(payload: unknown): payload is AnalyzeErrorPayload {
   return Boolean(payload && typeof payload === 'object' && 'error' in payload);
 }
@@ -138,9 +142,10 @@ export function PartBomTab({
         const isImageKind = attachmentKind === 'IMAGE';
         const mimeType = (attachment.mimeType ?? '').toLowerCase();
         const isImageMime = mimeType.startsWith('image/');
-        const isExplicitNonImageMime = Boolean(mimeType && !isImageMime);
-        if (isExplicitNonImageMime) return false;
-        return isPrintKind || isImageKind || isImageMime;
+        const isPdfMime = isPdfMimeType(mimeType);
+        const isExplicitUnsupportedMime = Boolean(mimeType && !isImageMime && !isPdfMime);
+        if (isExplicitUnsupportedMime) return false;
+        return isPrintKind || isImageKind || isImageMime || isPdfMime;
       }),
     [attachments]
   );
@@ -152,7 +157,7 @@ export function PartBomTab({
           const attachmentKind = (attachment.kind ?? '').toUpperCase();
           return {
             id: attachment.id,
-            label: attachment.label?.trim() || 'Image attachment',
+            label: attachment.label?.trim() || 'Print attachment',
             mimeType: attachment.mimeType ?? 'image/*',
             isPreferredPrint: attachmentKind === 'PRINT',
           };
@@ -249,32 +254,36 @@ export function PartBomTab({
 
   const getAttachmentDataUrl = async (attachmentId: string): Promise<string> => {
     const target = imageAttachments.find((attachment) => attachment.id === attachmentId);
-    if (!target) throw new Error('Selected image attachment was not found.');
+    if (!target) throw new Error('Selected print attachment was not found.');
 
     const openHref = target.storagePath ? `/attachments/${target.storagePath}` : target.url;
-    if (!openHref) throw new Error('Selected image attachment has no usable URL.');
+    if (!openHref) throw new Error('Selected print attachment has no usable URL.');
 
     const response = await fetch(openHref, { credentials: 'include' });
-    if (!response.ok) throw new Error('Failed to load selected image attachment.');
+    if (!response.ok) throw new Error('Failed to load selected print attachment.');
 
     const blob = await response.blob();
     const hintedMimeType = (target.mimeType ?? '').toLowerCase();
     const blobMimeType = (blob.type ?? '').toLowerCase();
+    const resolvedMimeType = hintedMimeType || blobMimeType;
+    const isPdf = isPdfMimeType(resolvedMimeType);
     const contentType = hintedMimeType.startsWith('image/')
       ? hintedMimeType
       : blobMimeType.startsWith('image/')
       ? blobMimeType
+      : isPdf
+      ? 'application/pdf'
       : 'image/png';
 
-    if (!hintedMimeType.startsWith('image/') && !blobMimeType.startsWith('image/')) {
-      throw new Error('Selected file is not an image. Choose a PNG/JPG/WEBP file in Notes & Files.');
+    if (!hintedMimeType.startsWith('image/') && !blobMimeType.startsWith('image/') && !isPdf) {
+      throw new Error('Selected file is not a supported print. Choose a PNG/JPG/WEBP/PDF file in Notes & Files.');
     }
 
     const base64 = await new Promise<string>((resolve, reject) => {
       const reader = new FileReader();
       reader.onload = () => resolve(String(reader.result ?? ''));
-      reader.onerror = () => reject(new Error('Failed to read selected image attachment.'));
-      reader.readAsDataURL(new File([blob], 'attachment-image', { type: contentType }));
+      reader.onerror = () => reject(new Error('Failed to read selected print attachment.'));
+      reader.readAsDataURL(new File([blob], isPdf ? 'attachment.pdf' : 'attachment-image', { type: contentType }));
     });
 
     return base64;
@@ -367,7 +376,7 @@ export function PartBomTab({
               <Input
                 id="bom-upload"
                 type="file"
-                accept="image/*"
+                accept="image/*,application/pdf"
                 className="bg-background/80"
                 onChange={(event) => {
                   setFile(event.currentTarget.files?.[0] ?? null);
@@ -375,7 +384,7 @@ export function PartBomTab({
                   setResult(null);
                 }}
               />
-              <p className="text-xs text-muted-foreground">PNG/JPG/WEBP screenshots or photos of the print. Files marked PRINT in Notes & Files are listed first above.</p>
+              <p className="text-xs text-muted-foreground">PNG/JPG/WEBP screenshots, photos, or first-page PDFs of the print. Files marked PRINT in Notes & Files are listed first above.</p>
             </div>
           </div>
 

--- a/src/app/private/print-analyzer/page.tsx
+++ b/src/app/private/print-analyzer/page.tsx
@@ -83,12 +83,12 @@ export default function PrintAnalyzerPage() {
       <div className={styles.container}>
         <section className={styles.card}>
           <h1 className={styles.heading}>Print Analyzer (Private)</h1>
-          <p className={styles.subtle}>Upload a print image and extract feature/tolerance data into structured JSON.</p>
+          <p className={styles.subtle}>Upload a print image or PDF and extract feature/tolerance data into structured JSON.</p>
 
           <div className={styles.row}>
             <input
               type="file"
-              accept="image/*"
+              accept="image/*,application/pdf"
               onChange={(event) => {
                 const picked = event.currentTarget.files?.[0] ?? null;
                 setFile(picked);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1984,3 +1984,34 @@ Commands run:
 - Replaced the mixed `??`/`||` prompt interpolation with a separate `currentDepartmentLabel` value so `/orders/[id]` can compile again.
 
 ---
+## Session Metadata
+- Date: 2026-04-09
+- Agent: Codex GPT-5
+- Task ID: BOM analyzer PDF upload support
+- Goal: Let the BOM analyzer accept PDF uploads and stored PDF print attachments by rasterizing the first page into an image before running the existing analyzer flow.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current blocker in code:
+  - BOM upload inputs only accept `image/*`,
+  - BOM attachment filtering excludes explicit non-image MIME types,
+  - `/api/print-analyzer/analyze` rejects anything not starting with `data:image/`.
+- [x] Confirmed the existing `sharp` build cannot rasterize PDFs here, so a dedicated server-side PDF renderer is required for reliable support.
+
+## Plan First
+- [x] Update BOM/private analyzer upload surfaces to accept `application/pdf` alongside images and stop filtering stored PDF print attachments out of the picker.
+- [x] Extend the print-analyzer API to accept `data:application/pdf;base64,...`, rasterize the first page to PNG, and then continue through the existing analysis pipeline.
+- [x] Update user-facing copy/docs so the supported upload types match the real behavior.
+- [x] Run relevant verification and update continuity docs with evidence.
+
+## Verification Checklist
+- [x] `npm run lint`
+- [x] PDF rasterization sanity check against a real stored PDF using `pdfjs-dist` + `@napi-rs/canvas`
+- [x] `npm run build` *(still fails in this environment for pre-existing `next/font` Roboto fetch / `127.0.0.1:9` connection issue, but no new PDF-renderer bundling error remains)*
+
+## Review + Results
+- BOM upload surfaces now accept `PDF` alongside images in both the order-detail BOM tab and the private analyzer page.
+- Stored `PRINT` attachments with `application/pdf` are now eligible in the BOM picker instead of being filtered out as unsupported non-images.
+- `/api/print-analyzer/analyze` now accepts `data:application/pdf` uploads, rasterizes page 1 to PNG with `pdfjs-dist` + `@napi-rs/canvas`, and then reuses the existing image-based analysis pipeline.
+- Added a Decision Log entry for the new PDF-rendering dependency choice and updated docs to reflect first-page PDF support.
+- Production build still fails in this workspace because of the existing `next/font` Roboto fetch / `127.0.0.1:9` environment issue, but the earlier native-canvas webpack parse failure introduced during this work has been eliminated.


### PR DESCRIPTION
## What changed
- added PDF support to the BOM analyzer upload surfaces in the order-detail BOM tab and the private analyzer page
- allowed stored `PRINT` attachments with `application/pdf` to appear in the BOM analyzer picker
- updated `POST /api/print-analyzer/analyze` to accept `data:application/pdf`, rasterize page 1 to PNG, and then reuse the existing image-based analyzer flow
- documented the new first-page PDF behavior and recorded the dependency/continuity updates

## Why
The BOM analyzer was image-only. PDF uploads and PDF print attachments were blocked in the picker/client, and the API rejected anything that was not `data:image/...`.

## Impact
Users can now analyze PDF prints without manually screenshotting them first. The analyzer still operates on images internally, but the PDF conversion step is now handled server-side.

## Validation
- `npm run lint`
- runtime PDF rasterization sanity check against a real stored PDF using `pdfjs-dist` + `@napi-rs/canvas`
- `npm run build` still fails in this environment because of the pre-existing `next/font` Roboto fetch / `127.0.0.1:9` connection issue, but the PDF renderer's earlier native-module bundling failure is resolved