### PR TITLE
[codex] Fix BOM analyzer PDF runtime loading

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1680,6 +1680,19 @@ Commands run:
 
 Verification note:
 - Lint passed with no ESLint warnings/errors.
+### 2026-04-10 — BOM analyzer PDF runtime loader follow-up
+- Fixed the PDF analyzer route's runtime module loading so PDF uploads work inside the live Next server bundle instead of failing on module-resolution errors.
+- Replaced the earlier `createRequire` / filesystem import approaches with runtime dynamic imports for both `pdfjs-dist` and `@napi-rs/canvas` in `src/app/api/print-analyzer/analyze/route.ts`.
+- Reclaimed port `3000` from the stale local Next process and restarted the updated workspace there so local testing matches the expected app URL.
+
+Commands run:
+- `npm run lint`
+- `node -` (live PDF smoke test against `http://127.0.0.1:3000/api/print-analyzer/analyze`)
+
+Verification note:
+- Lint passed with no ESLint warnings/errors.
+- Live PDF analyzer request on port `3000` returned `200` with structured JSON instead of the prior module-resolution failure.
+
 ### 2026-04-09 — BOM analyzer PDF upload support
 - Added PDF support to the BOM analyzer upload surfaces:
   - `/orders/[id]` BOM tab now accepts `application/pdf` in the file picker,

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -2827,6 +2827,36 @@ Goal (1 sentence): Make converted/new orders default part ownership to Machining
 - [ ] User verify on `/orders/[id]` that converted parts now land in Machining/current first department instead of showing `Unassigned`.
 - [ ] User verify that checking the last checklist item no longer makes the part appear to auto-move departments before using the manual submit/move action.
 - [ ] Optional follow-up: if the owner wants an even more aggressive left-rail reduction, split timer controls and part list into separate stacked cards on mobile/tablet breakpoints only.
+## Session Handoff — 2026-04-10 (BOM analyzer PDF runtime loader fix)
+
+Goal (1 sentence): Fix the PDF analyzer runtime import strategy so PDF uploads succeed on the live local Next server, especially on port `3000`.
+
+### What changed
+- Updated `src/app/api/print-analyzer/analyze/route.ts`
+  - Removed the earlier `createRequire` / filesystem-path PDF module loading approach that failed inside the Next bundled route runtime.
+  - Switched both `pdfjs-dist` and `@napi-rs/canvas` loading to runtime dynamic imports.
+  - Kept the existing page-1 PDF rasterization behavior and analyzer pipeline intact.
+- Local runtime verification
+  - Reclaimed port `3000` from the stale local Next process and restarted the updated workspace there.
+  - Confirmed the live analyzer route now accepts a PDF request successfully on `http://127.0.0.1:3000`.
+
+### Files touched
+- `src/app/api/print-analyzer/analyze/route.ts`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npm run lint`
+- `node -` (live PDF smoke test against `http://127.0.0.1:3000/api/print-analyzer/analyze`)
+
+### Verification evidence
+- Lint passed with no ESLint warnings/errors.
+- Live PDF analyzer request on port `3000` returned `200` with structured JSON instead of the earlier module-resolution error.
+
+### Next steps
+- [ ] Push this runtime-loader follow-up to the existing PR branch so the GitHub PR matches the working local server.
+
 ## Session Handoff — 2026-04-09 (BOM analyzer PDF upload support)
 
 Goal (1 sentence): Let the BOM analyzer accept PDFs by rasterizing page 1 to an image before running the existing analyzer flow.

--- a/src/app/api/print-analyzer/analyze/route.ts
+++ b/src/app/api/print-analyzer/analyze/route.ts
@@ -1,6 +1,3 @@
-import { createRequire } from 'node:module';
-import { pathToFileURL } from 'node:url';
-
 import OpenAI from 'openai';
 import sharp from 'sharp';
 import { NextResponse } from 'next/server';
@@ -25,9 +22,9 @@ const PASS_TWO_MODEL = 'gpt-4.1-mini';
 const PAPER_PRINT_MESSAGE = 'Unable to confidently read general tolerances. Please check the paper print.';
 const PDF_RENDER_SCALE = 2;
 const CANVAS_MODULE_NAME = ['@napi-rs', 'canvas'].join('/');
+const PDFJS_MODULE_NAME = ['pdfjs-dist', 'legacy', 'build', 'pdf.mjs'].join('/');
 
-const require = createRequire(import.meta.url);
-const loadCanvasModule = () => require(CANVAS_MODULE_NAME) as {
+type CanvasModule = {
   createCanvas: (width: number, height: number) => {
     width: number;
     height: number;
@@ -35,6 +32,11 @@ const loadCanvasModule = () => require(CANVAS_MODULE_NAME) as {
     encode: (format: 'png') => Promise<Uint8Array>;
   };
 };
+
+async function loadCanvasModule(): Promise<CanvasModule> {
+  const dynamicImport = new Function('specifier', 'return import(specifier);') as (specifier: string) => Promise<unknown>;
+  return (await dynamicImport(CANVAS_MODULE_NAME)) as CanvasModule;
+}
 
 type ModelPayload = {
   rawText: string;
@@ -101,12 +103,12 @@ type PdfPageProxy = {
 };
 
 class PdfCanvasFactory {
-  create(width: number, height: number) {
+  async create(width: number, height: number) {
     if (width <= 0 || height <= 0) {
       throw new Error('Invalid canvas size');
     }
 
-    const { createCanvas } = loadCanvasModule();
+    const { createCanvas } = await loadCanvasModule();
     const canvas = createCanvas(Math.ceil(width), Math.ceil(height));
     return {
       canvas,
@@ -130,8 +132,8 @@ class PdfCanvasFactory {
 }
 
 async function loadPdfJs(): Promise<PdfJsModule> {
-  const pdfJsPath = require.resolve('pdfjs-dist/legacy/build/pdf.mjs');
-  return (await import(pathToFileURL(pdfJsPath).href)) as PdfJsModule;
+  const dynamicImport = new Function('specifier', 'return import(specifier);') as (specifier: string) => Promise<unknown>;
+  return (await dynamicImport(PDFJS_MODULE_NAME)) as PdfJsModule;
 }
 
 async function rasterizePdfFirstPage(buffer: Buffer): Promise<Buffer> {
@@ -151,7 +153,7 @@ async function rasterizePdfFirstPage(buffer: Buffer): Promise<Buffer> {
       try {
         const viewport = page.getViewport({ scale: PDF_RENDER_SCALE });
         const canvasFactory = new PdfCanvasFactory();
-        const canvasAndContext = canvasFactory.create(viewport.width, viewport.height);
+        const canvasAndContext = await canvasFactory.create(viewport.width, viewport.height);
 
         try {
           await page.render({

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2015,3 +2015,27 @@ Commands run:
 - `/api/print-analyzer/analyze` now accepts `data:application/pdf` uploads, rasterizes page 1 to PNG with `pdfjs-dist` + `@napi-rs/canvas`, and then reuses the existing image-based analysis pipeline.
 - Added a Decision Log entry for the new PDF-rendering dependency choice and updated docs to reflect first-page PDF support.
 - Production build still fails in this workspace because of the existing `next/font` Roboto fetch / `127.0.0.1:9` environment issue, but the earlier native-canvas webpack parse failure introduced during this work has been eliminated.
+## Session Metadata
+- Date: 2026-04-10
+- Agent: Codex GPT-5
+- Task ID: BOM analyzer PDF runtime loader fix
+- Goal: Fix the PDF analyzer runtime import path so PDF uploads work on the live Next dev server, including the app running on port 3000.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the follow-up failure from the live app: PDF uploads still failed at runtime because the route could not resolve `pdfjs-dist` / `@napi-rs/canvas` correctly inside the Next bundled server context.
+
+## Plan First
+- [x] Replace the route's filesystem/`createRequire`-based PDF loader path with a runtime-safe dynamic import approach for both `pdfjs-dist` and `@napi-rs/canvas`.
+- [x] Verify the route still lints cleanly.
+- [x] Verify against the live local server on port `3000` with a real PDF upload request.
+- [x] Update continuity docs with the follow-up fix and evidence.
+
+## Verification Checklist
+- [x] `npm run lint`
+- [x] live `POST /api/print-analyzer/analyze` PDF smoke test against `http://127.0.0.1:3000`
+
+## Review + Results
+- The PDF analyzer route now resolves both `pdfjs-dist` and `@napi-rs/canvas` via runtime dynamic imports instead of the earlier module-path strategies that broke inside the Next server bundle.
+- Port `3000` was reclaimed from the stale local Next process and restarted with the updated workspace server.
+- A real PDF request to `http://127.0.0.1:3000/api/print-analyzer/analyze` now succeeds with `200` and structured analyzer JSON instead of the previous module-resolution failure.


### PR DESCRIPTION
## What changed
- fixed the BOM analyzer PDF route to load `pdfjs-dist` and `@napi-rs/canvas` with a runtime-safe dynamic import strategy
- kept the existing page-1 PDF rasterization flow intact
- verified the live local server on port `3000` after reclaiming it from a stale Next process

## Why
The first PDF-support PR was merged, but the live Next route still failed at runtime because the server bundle could not resolve the PDF/canvas modules correctly. That meant PDF uploads still errored even though the feature was wired through the picker and API contract.

## Impact
PDF uploads now work on the live app instead of failing with module-resolution errors during PDF-to-image conversion.

## Validation
- `npm run lint`
- live `POST /api/print-analyzer/analyze` PDF smoke test against `http://127.0.0.1:3000`
- verified the request now returns `200` with structured analyzer JSON instead of the prior runtime import failure