### PR TITLE
[codex] Fix order detail mission brief and layout follow-ups

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,3 +1,31 @@
+### 2026-04-10 - Order-detail layout shift for part-heavy orders
+- Reworked `src/app/orders/[id]/page.tsx` so the left rail is now dedicated to parts only instead of splitting space with the timer/work dock.
+- Added a dedicated scroll area for the part list so long orders stay navigable without the timer controls consuming that column.
+- Moved the timer department picker, timer start/pause/stop actions, submit action, complete-in-shipping action, and timer summary into the top of the right-side detail card.
+- Removed the admin order-status override UI and related client-side state from this page so the right side stays focused on the selected part.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed.
+
+### 2026-04-10 - Mission-brief acknowledge fix + quote conversion instruction seeding
+- Fixed the order-detail mission-brief modal on `src/app/orders/[id]/page.tsx` so empty instruction sets no longer trigger the broken acknowledgement path:
+  - department acknowledgement checks now short-circuit when a part has no `workInstructions`,
+  - the modal's primary action now safely continues/closes when there is nothing to acknowledge,
+  - manual acknowledgement no longer crashes on the success path when the dialog was opened without a pending gated action.
+- Updated quote-to-order prefill in `src/app/orders/new/page.tsx` so converted orders now seed part-level `workInstructions` from:
+  - quote-level `Requirements / process notes`,
+  - each part's quote `Part notes`.
+- Added a small conversion-mode review note clarifying where the mission-brief text comes from during quote conversion.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed on both touched UI files.
+
 ### 2026-04-10 - Order-detail UX polish follow-up
 - Tightened the mission-brief and worker-roster presentation in `src/app/orders/[id]/page.tsx`.
 - Mission brief now shows clearer acknowledgement copy plus quick chips for part, department, and instruction version.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,3 +1,60 @@
+## Session Handoff - 2026-04-10 (Order-detail layout shift for part-heavy orders)
+
+Goal (1 sentence): Give the full left side of `/orders/[id]` to the parts list, move timer/submit controls into the top of the right-side detail area, and remove the admin order-status override block from this screen.
+
+### What changed
+- Updated `src/app/orders/[id]/page.tsx`
+  - Removed the left-rail work-dock block entirely.
+  - Turned the left card into a dedicated parts-only panel with its own scroll area sized for long part lists.
+  - Moved timer controls, submit action, complete-in-shipping action, timer summary, and last-action context into the top summary area of the right-hand detail card.
+  - Removed the admin order-status override UI and its unused client-side state/handler from this page.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed.
+
+### Layout note for the next agent
+- The left rail is now intentionally parts-only for high-part-count orders.
+- Timer and submit controls now belong to the right-side header area above the tabbed part detail content; avoid reintroducing large non-part panels into the left column unless the owner explicitly asks for it.
+
+## Session Handoff - 2026-04-10 (Mission-brief acknowledge fix + quote conversion instruction seeding)
+
+Goal (1 sentence): Keep the mission-brief accept flow usable on order detail and ensure quote-created orders actually seed meaningful part-level mission-brief text.
+
+### What changed
+- Updated `src/app/orders/[id]/page.tsx`
+  - Fixed the department instruction-check helper so parts with no `workInstructions` are treated as having nothing to acknowledge instead of reopening the mission brief and failing with `This part has no required instructions.`
+  - Fixed the mission-brief confirm flow so manual acknowledgement no longer crashes when the dialog was opened without a gated pending action.
+  - Changed the empty-brief primary action label to `Continue` so the modal still has a clear exit path when no required-read text exists.
+- Updated `src/app/orders/new/page.tsx`
+  - Quote conversion prefill now seeds each part's `workInstructions` from quote-level `Requirements / process notes` plus that part's quote `Part notes`.
+  - Added conversion-mode review copy explaining where mission-brief instructions come from.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `src/app/orders/new/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed on both touched UI files.
+
+### Behavior note for the next agent
+- Mission-brief required-read text is driven by `OrderPart.workInstructions`, not general order notes.
+- For quote conversion, that field is now seeded from the quote's `Requirements / process notes` plus the part's `Part notes`; manual/repeat-order flows can still edit `Work instructions` directly from `/orders/new`.
+
 ## Session Handoff - 2026-04-10 (Order-detail UX polish)
 
 Goal (1 sentence): Apply a small clarity pass to the order-detail accountability UI so the mission brief and part-worker roster are easier to scan on the floor.

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -122,11 +122,6 @@ export default function OrderDetailPage() {
   const [activeTab, setActiveTab] = useState<PartTab>('overview');
   const [noteText, setNoteText] = useState('');
   const [canEditParts, setCanEditParts] = useState(false);
-  const [canEditOrderStatus, setCanEditOrderStatus] = useState(false);
-  const [statusDraft, setStatusDraft] = useState<'RECEIVED' | 'IN_PROGRESS' | 'COMPLETE' | 'CLOSED'>('RECEIVED');
-  const [statusReason, setStatusReason] = useState('');
-  const [statusSaving, setStatusSaving] = useState(false);
-  const [statusError, setStatusError] = useState<string | null>(null);
   const [partEvents, setPartEvents] = useState<any[]>([]);
   const [eventsLoading, setEventsLoading] = useState(false);
   const [timerError, setTimerError] = useState<string | null>(null);
@@ -438,9 +433,6 @@ export default function OrderDetailPage() {
           : []
       );
       setCanEditParts(Boolean(data?.permissions?.canEditParts));
-      setCanEditOrderStatus(Boolean(data?.permissions?.canEditOrderStatus));
-      setStatusDraft((data?.item?.status ?? 'RECEIVED') as 'RECEIVED' | 'IN_PROGRESS' | 'COMPLETE' | 'CLOSED');
-      setStatusError(null);
       setError(null);
       return data.item;
     } catch (err: any) {
@@ -640,6 +632,7 @@ export default function OrderDetailPage() {
   }, [loadPartEvents]);
 
   const isInstructionAcknowledgedForDepartment = (departmentId?: string | null) => {
+    if (!selectedPartInstructions) return true;
     if (!selectedPartId || !departmentId || !currentUserId) return !selectedPartInstructions;
     const receipts = Array.isArray(selectedPart?.instructionReceipts) ? selectedPart.instructionReceipts : [];
     return receipts.some(
@@ -679,6 +672,35 @@ export default function OrderDetailPage() {
       return;
     }
 
+    if (!selectedPartInstructions) {
+      setInstructionGateDialog({
+        open: false,
+        loading: false,
+        error: null,
+        pendingAction: null,
+      });
+      if (pendingAction?.kind === 'timer-start') {
+        await handleStart({ skipInstructionGate: true });
+      } else if (pendingAction?.kind === 'checklist-toggle') {
+        setChecklistPerformerDialog({
+          open: true,
+          loading: false,
+          error: null,
+          entry: pendingAction.entry,
+          checked: pendingAction.checked,
+          performerId: currentUserId || performerUsers[0]?.id || '',
+        });
+      } else if (pendingAction?.kind === 'submit-department') {
+        setSubmitConfirmDialog({
+          open: true,
+          destinationDepartmentId: pendingAction.destinationDepartmentId,
+          note: pendingAction.note,
+          error: null,
+        });
+      }
+      return;
+    }
+
     setInstructionGateDialog((prev) => ({ ...prev, loading: true, error: null }));
     try {
       const dismissKey = selectedPartId && selectedPartCurrentDepartmentId
@@ -706,9 +728,9 @@ export default function OrderDetailPage() {
       setDismissedInstructionGateKey(dismissKey);
       toast.push('Instructions acknowledged.', 'success');
 
-      if (pendingAction.kind === 'timer-start') {
+      if (pendingAction?.kind === 'timer-start') {
         await handleStart({ skipInstructionGate: true });
-      } else if (pendingAction.kind === 'checklist-toggle') {
+      } else if (pendingAction?.kind === 'checklist-toggle') {
         setChecklistPerformerDialog({
           open: true,
           loading: false,
@@ -717,7 +739,7 @@ export default function OrderDetailPage() {
           checked: pendingAction.checked,
           performerId: currentUserId || performerUsers[0]?.id || '',
         });
-      } else if (pendingAction.kind === 'submit-department') {
+      } else if (pendingAction?.kind === 'submit-department') {
         setSubmitConfirmDialog({
           open: true,
           destinationDepartmentId: pendingAction.destinationDepartmentId,
@@ -980,33 +1002,6 @@ export default function OrderDetailPage() {
     await handleActivateSelectedPart();
   };
 
-
-  const handleSaveStatus = async () => {
-    if (!id || !canEditOrderStatus) return;
-    setStatusSaving(true);
-    setStatusError(null);
-    try {
-      const res = await fetch(`/api/orders/${id}/status`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        credentials: 'include',
-        body: JSON.stringify({ status: statusDraft, reason: statusReason }),
-      });
-      if (!res.ok) {
-        const payload = await res.json().catch(() => null);
-        throw new Error(typeof payload?.error === 'string' ? payload.error : 'Failed to update order status.');
-      }
-      setStatusReason('');
-      await load();
-      toast.push('Order status updated.', 'success');
-    } catch (err: any) {
-      const message = err?.message || 'Failed to update order status.';
-      setStatusError(message);
-      toast.push(message, 'error');
-    } finally {
-      setStatusSaving(false);
-    }
-  };
 
   const handleSaveRepeatTemplate = async () => {
     if (!id || !canEditParts) return;
@@ -1765,7 +1760,7 @@ export default function OrderDetailPage() {
               Not now
             </Button>
             <Button type="button" onClick={() => void handleInstructionGateConfirm()} disabled={instructionGateDialog.loading}>
-              {instructionGateDialog.loading ? 'Accepting…' : 'I have read this'}
+              {!selectedPartInstructions ? 'Continue' : instructionGateDialog.loading ? 'Accepting…' : 'I have read this'}
             </Button>
           </DialogFooter>
         </DialogContent>
@@ -1890,186 +1885,20 @@ export default function OrderDetailPage() {
         </DialogContent>
       </Dialog>
 
-      <div className="grid gap-6 lg:grid-cols-[320px_1fr]">
-        <Card className="flex flex-col">
+      <div className="grid gap-6 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <Card className="flex min-h-0 flex-col">
           <div className="sticky top-0 z-10 border-b border-border/60 bg-background/95 p-4">
-            <div className="grid gap-3">
-              <div className="flex flex-wrap items-center justify-between gap-3">
-                <div className="space-y-1">
-                  <div className="text-xs uppercase tracking-wide text-muted-foreground">Work Dock</div>
-                  <div className="text-sm font-medium text-foreground">
-                    {selectedPart?.partNumber || 'No part selected'}
-                  </div>
-                  <div className="text-xs text-muted-foreground">
-                    {selectedPartId ? `Elapsed ${formatDuration(selectedPartElapsedSeconds)}` : 'No part selected'}
-                  </div>
-                </div>
-                {activeOnSelected ? (
-                  <Badge className="bg-emerald-500/15 text-emerald-200">Running</Badge>
-                ) : activeElsewhereEntry?.href ? (
-                  <Button asChild size="sm" variant="ghost" className="h-7 bg-emerald-500/15 px-2 text-emerald-200 hover:bg-emerald-500/25 hover:text-emerald-100">
-                    <Link href={activeElsewhereEntry.href} title={`Open ${activeElsewhereEntry.order?.orderNumber || 'active order'}${activeElsewhereEntry.part?.partNumber ? ` / ${activeElsewhereEntry.part.partNumber}` : ''}`}>
-                      {otherTimerBadgeLabel}
-                    </Link>
-                  </Button>
-                ) : (
-                  <Badge className={hasActiveEntry ? 'bg-emerald-500/15 text-emerald-200' : 'bg-muted text-foreground'}>
-                    {hasActiveEntry ? otherTimerBadgeLabel : 'Idle'}
-                  </Badge>
-                )}
-              </div>
-
-              <div className="grid gap-2 sm:grid-cols-2">
-                <Select value={selectedTimerDepartmentId} onValueChange={setSelectedTimerDepartmentId}>
-                  <SelectTrigger className="h-8">
-                    <SelectValue placeholder="Choose timer department" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {timerDepartments.map((department) => (
-                      <SelectItem key={department.id} value={department.id}>
-                        {department.name}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <Button
-                  type="button"
-                  size="sm"
-                  disabled={!selectedPartId || timerSaving || activeOnSelected || !selectedTimerDepartmentId}
-                  onClick={handleActivateSelectedPart}
-                  className="justify-start gap-2"
-                >
-                  <Play className="h-4 w-4" />
-                  Start timer
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  disabled={!selectedActiveEntry || timerSaving}
-                  onClick={() => void handlePause(selectedActiveEntry?.id)}
-                  className="justify-start gap-2"
-                >
-                  <PauseCircle className="h-4 w-4" />
-                  Pause
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  disabled={!selectedActiveEntry || timerSaving}
-                  onClick={() => void handleFinish(selectedActiveEntry?.id)}
-                  className="justify-start gap-2"
-                >
-                  <Square className="h-4 w-4" />
-                  Stop
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="outline"
-                  disabled={!selectedPartId || timerSaving || activeOnSelected || !submitDestinationOptions.length}
-                  onClick={openMoveDepartmentDialog}
-                  className="justify-start gap-2"
-                >
-                  <CheckCircle2 className="h-4 w-4" />
-                  Submit To
-                </Button>
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="secondary"
-                  disabled={!selectedPartId || timerSaving || !canMarkPartComplete}
-                  onClick={handleCompleteSelectedPart}
-                  className="justify-start gap-2"
-                >
-                  <CheckCircle2 className="h-4 w-4" />
-                  Complete in Shipping
-                </Button>
-              </div>
-
-              <div className="grid gap-2 rounded-md border border-border/60 bg-muted/10 p-3 text-xs text-muted-foreground md:grid-cols-2">
-                <div className="flex items-start gap-2">
-                  <ArrowRightLeft className="mt-0.5 h-3.5 w-3.5" />
-                  <span>{startHelperLabel}</span>
-                </div>
-                <div>
-                  {lastPartEvent ? (
-                    <span>
-                      Last action: <span className="font-medium text-foreground">{lastPartEvent.message}</span> ·{' '}
-                      {new Date(lastPartEvent.createdAt).toLocaleString()}
-                    </span>
-                  ) : (
-                    <span>Last action: none yet for this part.</span>
-                  )}
-                </div>
-              </div>
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span className="uppercase tracking-wide">Parts</span>
+              {timerLoading ? <span>Refreshing…</span> : <span>{parts.length} total</span>}
             </div>
-            {timerError ? (
-              <div className="mt-3 rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                {timerError}
-              </div>
-            ) : null}
-            {selectedPartId ? (
-              <div className="mt-3 rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
-                <div><span className="font-medium text-foreground">Total time:</span> {formatDuration(selectedPartStoredSeconds)}</div>
-                <div>Timer time: {formatDuration(selectedPartTimerSeconds)}</div>
-                <div className="flex items-center justify-between gap-3">
-                  <span>Manual added time: {formatDuration(selectedPartManualSeconds)}</span>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="ghost"
-                    onClick={() => setShowTimerDetails((prev) => !prev)}
-                    className="h-7 px-2 text-xs"
-                  >
-                    {showTimerDetails ? 'Hide details' : 'Show details'}
-                  </Button>
-                </div>
-                {showTimerDetails && partManualAdjustments.length ? (
-                  <div className="mt-2 space-y-1">
-                    {partManualAdjustments.map((adjustment: any) => (
-                      <div key={adjustment.id}>
-                        +{formatDuration(Number(adjustment.seconds ?? 0))} — {adjustment.note}
-                      </div>
-                    ))}
-                  </div>
-                ) : null}
-                {showTimerDetails && selectedPartDepartmentHistory.length ? (
-                  <div className="mt-3 space-y-2">
-                    <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Department history totals</div>
-                    <div className="grid gap-2">
-                      {selectedPartDepartmentHistory.map((group) => (
-                        <div key={group.departmentId ?? '__none__'} className="rounded border border-border/60 bg-background/70 p-2">
-                          <div className="text-[11px] text-muted-foreground">{group.departmentName}</div>
-                          <div className="text-sm font-semibold text-foreground">{formatDuration(group.totalSeconds)}</div>
-                        </div>
-                      ))}
-                    </div>
-                    <div className="space-y-1">
-                      {selectedPartDepartmentHistory.map((group) => (
-                        <div key={`${group.departmentId ?? '__none__'}_rows`} className="rounded border border-border/50 bg-background/50 p-2">
-                          <div className="mb-1 text-[11px] font-medium text-foreground">{group.departmentName}</div>
-                          {group.entries.slice(0, 3).map((entry: any) => (
-                            <div key={entry.id} className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
-                              <span>{new Date(entry.startedAt).toLocaleString()}</span>
-                              <span className="font-medium text-foreground">{formatDuration(entry.durationSeconds)}</span>
-                            </div>
-                          ))}
-                        </div>
-                      ))}
-                    </div>
-                  </div>
-                ) : null}
-              </div>
-            ) : null}
           </div>
-          <CardContent className="flex-1 space-y-3 p-4">
+          <CardContent className="flex-1 min-h-0 space-y-3 overflow-hidden p-4">
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>Parts</span>
-              {timerLoading ? <span>Refreshing…</span> : null}
+              <span>{selectedPartId ? 'Select a part to inspect details' : 'Choose a part to begin'}</span>
             </div>
-            <div className="space-y-2">
+            <div className="max-h-[calc(100vh-260px)] space-y-2 overflow-y-auto pr-1">
               {parts.map((part: any, index: number) => {
                 const isSelected = part.id === selectedPartId;
                 const partLabel = part.partNumber || `Part ${index + 1}`;
@@ -2155,55 +1984,177 @@ export default function OrderDetailPage() {
                   </Button>
                 </div>
               ) : null}
-              {canEditOrderStatus ? (
-                <div className="grid gap-3 lg:grid-cols-[200px_minmax(0,1fr)_auto] lg:items-end">
-                  <div className="grid gap-2">
-                    <Label className="text-xs uppercase tracking-wide text-muted-foreground">Order status</Label>
-                    <Select
-                      value={statusDraft}
-                      onValueChange={(value) => {
-                        setStatusDraft(value as 'RECEIVED' | 'IN_PROGRESS' | 'COMPLETE' | 'CLOSED');
-                        setStatusError(null);
-                      }}
-                    >
-                      <SelectTrigger className="border-border/60 bg-background/80 text-left">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="RECEIVED">Received</SelectItem>
-                        <SelectItem value="IN_PROGRESS">In progress</SelectItem>
-                        <SelectItem value="COMPLETE">Complete</SelectItem>
-                        <SelectItem value="CLOSED">Closed</SelectItem>
-                      </SelectContent>
-                    </Select>
+              <div className="space-y-3 rounded-lg border border-border/60 bg-background/70 p-4">
+                <div className="flex flex-wrap items-center justify-between gap-3">
+                  <div className="space-y-1">
+                    <div className="text-xs uppercase tracking-wide text-muted-foreground">Part Controls</div>
+                    <div className="text-sm font-medium text-foreground">
+                      {selectedPart?.partNumber || 'No part selected'}
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      {selectedPartId ? `Elapsed ${formatDuration(selectedPartElapsedSeconds)}` : 'Pick a part from the left to start work.'}
+                    </div>
                   </div>
-                  <div className="grid gap-2">
-                    <Label className="text-xs uppercase tracking-wide text-muted-foreground">Admin reason</Label>
-                    <Textarea
-                      rows={2}
-                      value={statusReason}
-                      onChange={(e) => {
-                        setStatusReason(e.target.value);
-                        setStatusError(null);
-                      }}
-                      placeholder="Why are you changing the order status?"
-                    />
-                  </div>
-                  <div className="flex flex-col gap-2 lg:items-end">
-                    <Button size="sm" onClick={handleSaveStatus} disabled={statusSaving}>
-                      {statusSaving ? 'Saving…' : 'Save status'}
+                  {activeOnSelected ? (
+                    <Badge className="bg-emerald-500/15 text-emerald-200">Running</Badge>
+                  ) : activeElsewhereEntry?.href ? (
+                    <Button asChild size="sm" variant="ghost" className="h-7 bg-emerald-500/15 px-2 text-emerald-200 hover:bg-emerald-500/25 hover:text-emerald-100">
+                      <Link href={activeElsewhereEntry.href} title={`Open ${activeElsewhereEntry.order?.orderNumber || 'active order'}${activeElsewhereEntry.part?.partNumber ? ` / ${activeElsewhereEntry.part.partNumber}` : ''}`}>
+                        {otherTimerBadgeLabel}
+                      </Link>
                     </Button>
-                    <p className="max-w-xs text-xs text-muted-foreground lg:text-right">
-                      Admin override. Shop-floor part activity will still auto-sync this order later.
-                    </p>
+                  ) : (
+                    <Badge className={hasActiveEntry ? 'bg-emerald-500/15 text-emerald-200' : 'bg-muted text-foreground'}>
+                      {hasActiveEntry ? otherTimerBadgeLabel : 'Idle'}
+                    </Badge>
+                  )}
+                </div>
+
+                <div className="grid gap-2 lg:grid-cols-[220px_repeat(4,minmax(0,1fr))]">
+                  <Select value={selectedTimerDepartmentId} onValueChange={setSelectedTimerDepartmentId}>
+                    <SelectTrigger className="h-9 border-border/60 bg-background/80">
+                      <SelectValue placeholder="Choose timer department" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {timerDepartments.map((department) => (
+                        <SelectItem key={department.id} value={department.id}>
+                          {department.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    type="button"
+                    size="sm"
+                    disabled={!selectedPartId || timerSaving || activeOnSelected || !selectedTimerDepartmentId}
+                    onClick={handleActivateSelectedPart}
+                    className="justify-center gap-2"
+                  >
+                    <Play className="h-4 w-4" />
+                    Start timer
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!selectedActiveEntry || timerSaving}
+                    onClick={() => void handlePause(selectedActiveEntry?.id)}
+                    className="justify-center gap-2"
+                  >
+                    <PauseCircle className="h-4 w-4" />
+                    Pause
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    disabled={!selectedActiveEntry || timerSaving}
+                    onClick={() => void handleFinish(selectedActiveEntry?.id)}
+                    className="justify-center gap-2"
+                  >
+                    <Square className="h-4 w-4" />
+                    Stop
+                  </Button>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!selectedPartId || timerSaving || activeOnSelected || !submitDestinationOptions.length}
+                    onClick={openMoveDepartmentDialog}
+                    className="justify-center gap-2"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    Submit to
+                  </Button>
+                </div>
+
+                <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/10 p-3 text-xs text-muted-foreground">
+                  <div className="flex items-start gap-2">
+                    <ArrowRightLeft className="mt-0.5 h-3.5 w-3.5" />
+                    <span>{startHelperLabel}</span>
                   </div>
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="secondary"
+                    disabled={!selectedPartId || timerSaving || !canMarkPartComplete}
+                    onClick={handleCompleteSelectedPart}
+                    className="gap-2"
+                  >
+                    <CheckCircle2 className="h-4 w-4" />
+                    Complete in Shipping
+                  </Button>
                 </div>
-              ) : null}
-              {statusError ? (
-                <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
-                  {statusError}
+
+                {timerError ? (
+                  <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                    {timerError}
+                  </div>
+                ) : null}
+                {selectedPartId ? (
+                  <div className="rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
+                    <div><span className="font-medium text-foreground">Total time:</span> {formatDuration(selectedPartStoredSeconds)}</div>
+                    <div>Timer time: {formatDuration(selectedPartTimerSeconds)}</div>
+                    <div className="flex items-center justify-between gap-3">
+                      <span>Manual added time: {formatDuration(selectedPartManualSeconds)}</span>
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="ghost"
+                        onClick={() => setShowTimerDetails((prev) => !prev)}
+                        className="h-7 px-2 text-xs"
+                      >
+                        {showTimerDetails ? 'Hide details' : 'Show details'}
+                      </Button>
+                    </div>
+                    {showTimerDetails && partManualAdjustments.length ? (
+                      <div className="mt-2 space-y-1">
+                        {partManualAdjustments.map((adjustment: any) => (
+                          <div key={adjustment.id}>
+                            +{formatDuration(Number(adjustment.seconds ?? 0))} — {adjustment.note}
+                          </div>
+                        ))}
+                      </div>
+                    ) : null}
+                    {showTimerDetails && selectedPartDepartmentHistory.length ? (
+                      <div className="mt-3 space-y-2">
+                        <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Department history totals</div>
+                        <div className="grid gap-2 md:grid-cols-2">
+                          {selectedPartDepartmentHistory.map((group) => (
+                            <div key={group.departmentId ?? '__none__'} className="rounded border border-border/60 bg-background/70 p-2">
+                              <div className="text-[11px] text-muted-foreground">{group.departmentName}</div>
+                              <div className="text-sm font-semibold text-foreground">{formatDuration(group.totalSeconds)}</div>
+                            </div>
+                          ))}
+                        </div>
+                        <div className="space-y-1">
+                          {selectedPartDepartmentHistory.map((group) => (
+                            <div key={`${group.departmentId ?? '__none__'}_rows`} className="rounded border border-border/50 bg-background/50 p-2">
+                              <div className="mb-1 text-[11px] font-medium text-foreground">{group.departmentName}</div>
+                              {group.entries.slice(0, 3).map((entry: any) => (
+                                <div key={entry.id} className="flex items-center justify-between gap-2 text-[11px] text-muted-foreground">
+                                  <span>{new Date(entry.startedAt).toLocaleString()}</span>
+                                  <span className="font-medium text-foreground">{formatDuration(entry.durationSeconds)}</span>
+                                </div>
+                              ))}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+                <div className="text-xs text-muted-foreground">
+                  {lastPartEvent ? (
+                    <span>
+                      Last action: <span className="font-medium text-foreground">{lastPartEvent.message}</span> ·{' '}
+                      {new Date(lastPartEvent.createdAt).toLocaleString()}
+                    </span>
+                  ) : (
+                    <span>Last action: none yet for this part.</span>
+                  )}
                 </div>
-              ) : null}
+              </div>
             </div>
             <div className="flex gap-2 overflow-x-auto whitespace-nowrap rounded-md bg-muted/20 p-1">
               {visibleTabs.map((tab) => {

--- a/src/app/orders/new/page.tsx
+++ b/src/app/orders/new/page.tsx
@@ -150,6 +150,15 @@ const buildConversionNote = (quote: any) => {
   return content.length ? content : '';
 };
 
+const buildConversionWorkInstructions = (quote: any, part: any) => {
+  const sections: string[] = [];
+  const quoteRequirements = typeof quote?.requirements === 'string' ? quote.requirements.trim() : '';
+  const partSpecificNote = typeof part?.notes === 'string' ? part.notes.trim() : '';
+  if (quoteRequirements) sections.push(`Quote requirements:\n${quoteRequirements}`);
+  if (partSpecificNote) sections.push(`Part-specific note:\n${partSpecificNote}`);
+  return sections.join('\n\n').trim();
+};
+
 const defaultDueDate = () => {
   const base = new Date();
   base.setDate(base.getDate() + 14);
@@ -378,6 +387,7 @@ function NewOrderForm() {
                       stockSize: part.stockSize ?? null,
                       cutLength: part.cutLength ?? null,
                     }),
+                    workInstructions: buildConversionWorkInstructions(quote, part),
                     addonSelections: selections.map((selection: any) => ({
                       key: createKey(),
                       addonId: selection.addonId ?? selection.addon?.id ?? '',
@@ -1976,7 +1986,7 @@ function NewOrderForm() {
                 )}
                 {conversionMode && (
                   <div className="rounded-lg border border-border/60 bg-background/60 p-4 text-sm text-muted-foreground">
-                    Add-ons and labor will copy from the quote parts and become part-level charges and checklist items.
+                    Add-ons and labor will copy from the quote parts and become part-level charges and checklist items. Mission-brief instructions will seed from quote requirements plus each part&apos;s quote notes.
                   </div>
                 )}
                 <div className="grid gap-2">

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,3 +1,60 @@
+## Session Metadata
+- Date: 2026-04-10
+- Agent: Codex GPT-5
+- Task ID: Order-detail layout shift for part-heavy orders
+- Goal: Give the full left rail to the parts list, move timer/submit controls into the top of the right-side detail area, and remove the admin order-status block from this screen.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current gap in `src/app/orders/[id]/page.tsx`:
+  - the left rail still dedicated a large sticky area to the work dock instead of maximizing part-list visibility,
+  - the right header still used space for admin-only order-status override controls,
+  - long part lists did not have a dedicated scroll area optimized for 30-50 part orders.
+
+## Plan First
+- [x] Remove the left-rail work dock and make that column a dedicated parts-only panel with its own scrollable list.
+- [x] Move timer/submit/complete controls into the right-side top summary area where the status override block lived.
+- [x] Remove the admin order-status override UI/state from this page.
+- [x] Run focused verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+## Review + Results
+- The left rail on `/orders/[id]` is now reserved for the parts list, with a dedicated scroll area sized for long orders.
+- The timer department picker, timer controls, submit action, complete-in-shipping action, and timer summary now live at the top of the right-side detail card.
+- Removed the admin order-status override block and its client-side state from this page so the right side stays focused on the selected part.
+
+## Session Metadata
+- Date: 2026-04-10
+- Agent: Codex GPT-5
+- Task ID: Mission-brief accept flow + quote-note sourcing
+- Goal: Keep the mission-brief modal acknowledge action usable, and make quote-created orders feed meaningful required-read instructions into the part-level mission brief instead of leaving it empty.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current issue in code:
+  - the mission-brief modal still posts an acknowledgement even when a part has no `workInstructions`, which triggers the backend error `This part has no required instructions.`,
+  - quote conversion currently fills general order `notes` and part `notes`, but does not populate part `workInstructions`, so the acknowledgement flow often has nothing real to read.
+
+## Plan First
+- [x] Patch the order-detail mission-brief modal so the primary action behaves cleanly when there are no required instructions.
+- [x] Patch quote-to-order prefill so quote requirements/notes seed the part-level `workInstructions` field used by the mission brief.
+- [x] Run focused verification on the touched UI files.
+- [x] Update continuity docs with evidence and the clarified note-source behavior.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx"`
+
+## Review + Results
+- Fixed the mission-brief gating bug on `/orders/[id]`:
+  - empty `workInstructions` now short-circuit as "nothing required" instead of reopening the modal and failing the acknowledgement POST,
+  - manual brief acknowledgement no longer crashes when the dialog was opened without a pending gated action.
+- Quote conversion prefill on `/orders/new?quoteId=...` now seeds each part's `workInstructions` from:
+  - quote-level `Requirements / process notes`,
+  - that part's quote `Part notes`.
+- Added a small conversion-mode hint in the order-create review UI so the source of mission-brief text is visible during launch.
+
 ## Repeat Orders + Operator Accountability v1 - Final Integration
 - [x] Prisma/data model changes landed for repeat templates, part assignments, instruction receipts, checklist performer attribution, and part work instructions.
 - [x] Repeat-order backend/API landed: snapshot from order, list/fetch templates, create order from template.


### PR DESCRIPTION
## What changed
- fixed the mission-brief acknowledgement flow on `/orders/[id]` so empty instruction sets no longer trigger a broken acknowledge request and manual brief review no longer crashes when opened without a pending gated action
- updated quote-to-order prefill on `/orders/new?quoteId=...` so part-level `workInstructions` seed from quote requirements plus each part's quote notes
- reworked the order-detail layout so the left rail is dedicated to the parts list, while timer and submit controls now live at the top of the right-side detail area
- removed the admin order-status override UI from the order-detail page
- updated continuity docs for the shipped fixes

## Why
The current order-detail workflow had a few operator-facing issues:
- the mission brief could fail even when there was nothing to acknowledge
- quote-created orders often showed no meaningful required-read text because the brief field was never seeded from quote data
- the timer/work dock consumed too much of the left rail, which made high-part-count orders harder to work through

## User impact
- operators can acknowledge or dismiss the mission brief cleanly
- converted orders now carry more useful setup/process guidance into the part-level mission brief
- the parts list gets the full left rail and its own scrollable area for larger orders

## Validation
- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx"`