### PR TITLE
Embed kiosk timing flow into order detail

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,3 +1,57 @@
+### 2026-04-10 - Order-detail kiosk timing follow-up: embedded PIN + part picker on `/orders/[id]`
+- Reworked the kiosk-only timer experience on `src/app/orders/[id]/page.tsx` so kiosk-enabled machinists no longer have to leave the order-detail page to start or manage time.
+- Replaced the old `Open kiosk` fallback with in-page kiosk controls in the existing timer area:
+  - `Start timer` now opens a dialog on the order page,
+  - the dialog now requires worker, department, and PIN selection before start,
+  - the dialog lets the user choose a part from the current order before starting.
+- Added in-page kiosk pause/stop handling on the same timer header, including PIN re-unlock when the kiosk session is missing.
+- Reused the existing kiosk unlock/session/start/pause/finish/switch API routes so worker ownership, default-department usage, and active-timer switch confirmation all stay server-enforced.
+- Collapsed the extra kiosk/timer helper copy, time breakdown, and last-action readout behind the existing `Show details` affordance so the timer header stays visually quiet by default.
+- Follow-up simplification: the order-detail worker picker now treats all active users as eligible for this PIN flow instead of filtering by `kioskEnabled`, while still requiring that selected user's PIN.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed.
+
+### 2026-04-10 - Shared kiosk timing + read-only order detail for floor users
+- Added kiosk-ready user timing fields and admin management support:
+  - `User.kioskEnabled`,
+  - `User.kioskPinHash`,
+  - `User.primaryDepartmentId`.
+- Added `src/lib/kiosk-session.ts` and dedicated kiosk API routes under `src/app/api/kiosk/**` for:
+  - PIN unlock,
+  - kiosk session fetch,
+  - kiosk lock/reset,
+  - department part search,
+  - worker-scoped timer start/pause/finish.
+- Added `/kiosk` as a dedicated timing-only shared-station page:
+  - PIN unlock,
+  - current worker + active timer status,
+  - primary-department default with override,
+  - searchable department-ready part list,
+  - explicit pause/stop/switch flow.
+- Changed timer behavior to one active timer total per worker instead of one active timer per worker per department.
+- Added reporting-oriented timer summaries in `src/modules/time/time.service.ts` for:
+  - totals by part + department,
+  - totals by part + user,
+  - totals by department + user,
+  - active timer by user.
+- Kept `/orders/[id]` readable for floor workers but now hides timer controls for kiosk-enabled machinists and points them to `/kiosk` for timing.
+- Hardened user-repo sanitization so kiosk PIN hashes are no longer leaked through sanitized user payloads.
+
+Commands run:
+- `npx prisma migrate dev --name kiosk_user_timing_v1`
+- `npx eslint --ext .ts,.tsx -- "src/app/kiosk/page.tsx" "src/app/api/kiosk/unlock/route.ts" "src/app/api/kiosk/session/route.ts" "src/app/api/kiosk/lock/route.ts" "src/app/api/kiosk/parts/route.ts" "src/app/api/kiosk/timer/route.ts" "src/app/api/orders/[id]/route.ts" "src/app/api/timer/start/route.ts" "src/app/orders/[id]/page.tsx" "src/components/AppNav.tsx" "src/modules/kiosk/kiosk.service.ts" "src/modules/kiosk/kiosk.schema.ts" "src/modules/time/time.service.ts" "src/modules/users/users.repo.ts" "src/repos/users.ts" "src/repos/mock/users.ts" "src/repos/mock/seed.ts" "src/modules/time/__tests__/time.service.test.ts" "src/modules/kiosk/__tests__/kiosk.service.test.ts"`
+- `npm run test -- src/modules/time/__tests__/time.service.test.ts src/modules/kiosk/__tests__/kiosk.service.test.ts`
+
+Verification note:
+- Prisma migration applied successfully and created `prisma/migrations/20260410174437_kiosk_user_timing_v1/migration.sql`.
+- Targeted ESLint passed.
+- Focused kiosk/time tests passed (`11/11`) after an outside-sandbox rerun because sandboxed Vitest/esbuild hit Windows `spawn EPERM`.
+- Prisma generate inside the migration hit a Windows file-lock `EPERM` while renaming the Prisma query engine DLL, but the migration completed and the focused checks passed afterward.
+
 ### 2026-04-10 - Order-detail layout shift for part-heavy orders
 - Reworked `src/app/orders/[id]/page.tsx` so the left rail is now dedicated to parts only instead of splitting space with the timer/work dock.
 - Added a dedicated scroll area for the part list so long orders stay navigable without the timer controls consuming that column.

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -60,6 +60,14 @@ Goal: a scalable foundation that can grow.
 
 ## Decision Log (append newest at top)
 
+### 2026-04-10 - Order detail is now the primary kiosk-timing entry for floor users
+Decision: Keep the kiosk session/PIN/timer APIs and `/kiosk` route, but move the primary worker-facing kiosk timing flow back into `/orders/[id]` by opening an in-page PIN + part-picker dialog from the order-detail timer area for kiosk-enabled machinists.
+Reason: Floor users already live in order detail while reviewing notes/files/checklists, so sending them to a separate kiosk page for the same timer action adds friction without changing the timer enforcement model.
+
+### 2026-04-10 - Floor timing uses a dedicated kiosk with user-owned timers; `/orders/[id]` stays review-first
+Decision: Add PIN-based kiosk identity on `User` (`kioskEnabled`, `kioskPinHash`, `primaryDepartmentId`), move floor timing into a dedicated `/kiosk` flow with its own signed kiosk session, enforce one active timer total per worker, and keep `/orders/[id]` readable for floor workers while hiding timer controls there for kiosk-enabled machinists.
+Reason: The shop has shared-floor computers and workers who still need order notes/files/checklists but get confused by timer controls in the full order view. User-owned kiosk timing preserves worker accountability and bottleneck reporting without forcing five persistent browser logins or multiple incognito-tab identities.
+
 ### 2026-04-10 - Repeat-order backend snapshots manufacturing definition only and validates template-instantiation inputs strictly
 Decision: Repeat-order template snapshotting must not carry the source order PO into template defaults, template-based order creation must reject unknown or duplicate `templatePartId` overrides, provided order numbers must obey the same business-prefix rule as standard order creation, and template instantiation must fail fast when a template has no parts.
 Reason: Repeat orders should preserve reusable manufacturing intent without leaking stale execution/chatter fields, and the backend must keep template instantiation deterministic so the UI cannot silently create malformed orders from bad override payloads.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,3 +1,122 @@
+## Session Handoff - 2026-04-10 (Order-detail embedded kiosk timing follow-up)
+
+Goal (1 sentence): Keep kiosk timing rules intact, but let kiosk-enabled machinists start and manage timers directly from the order-detail timer area instead of bouncing out to a separate kiosk page.
+
+### What changed
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/[id]/page.tsx)
+  - Replaced the old kiosk-only fallback message/link in the timer area with in-page kiosk controls.
+  - Added an order-detail kiosk dialog that:
+    - requires worker selection, department selection, and PIN entry for kiosk timer starts,
+    - lets the worker choose a part from the current order,
+    - starts the timer without leaving `/orders/[id]`.
+- Added in-page kiosk pause/stop handling, including PIN re-unlock when needed.
+- Reused the existing kiosk start/switch behavior so active-timer conflicts still surface `Pause & switch` / `Stop & switch`.
+- Moved the extra kiosk helper copy, timer breakdown, and last-action text under `Show details` so the timer header stays compact by default.
+- Follow-up: the worker picker now uses all active users, not just kiosk-enabled users; PIN is still required for the selected worker.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed.
+
+### Behavior note for the next agent
+- `/kiosk` still exists, but `/orders/[id]` now owns the primary kiosk timing workflow for kiosk-enabled machinists.
+- The order-detail kiosk dialog intentionally reuses the existing kiosk unlock/session/timer APIs rather than calling normal `/api/timer/*` routes directly.
+- Order-detail kiosk starts now require explicit worker + department + PIN selection.
+- The selected worker's primary department is used only as a default suggestion in the dialog, not as a hidden/forced choice.
+- The backend kiosk-service path no longer blocks selected workers based on `kioskEnabled`; it only requires an active user plus that user's PIN.
+
+## Session Handoff - 2026-04-10 (Shared kiosk timing + read-only order detail for floor users)
+
+Goal (1 sentence): Move floor timing into a dedicated shared-computer kiosk while keeping `/orders/[id]` available for job review and hiding timer controls there for kiosk-designated machinists.
+
+### What changed
+- Prisma/data model
+  - Added `User.kioskEnabled`, `User.kioskPinHash`, and `User.primaryDepartmentId`.
+  - Added `prisma/migrations/20260410174437_kiosk_user_timing_v1/migration.sql`.
+- Admin user management
+  - Updated the admin users schema/UI/API so admins can enable kiosk timing, assign a primary department, and set/reset a worker PIN.
+  - Hardened sanitized user payloads so `kioskPinHash` is not leaked.
+- Timer backend
+  - Changed timer enforcement in `src/modules/time/time.service.ts` from one-active-per-user-per-department to one-active-per-user-total.
+  - Added reporting-oriented timer summaries keyed by part/department/user.
+  - Simplified timer conflict lookup in `src/app/api/timer/start/route.ts` to use the worker’s single active timer.
+- Kiosk flow
+  - Added `src/lib/kiosk-session.ts` for signed kiosk cookie sessions.
+  - Added `src/modules/kiosk/kiosk.schema.ts` and `src/modules/kiosk/kiosk.service.ts`.
+  - Added kiosk routes:
+    - `src/app/api/kiosk/unlock/route.ts`
+    - `src/app/api/kiosk/session/route.ts`
+    - `src/app/api/kiosk/lock/route.ts`
+    - `src/app/api/kiosk/parts/route.ts`
+    - `src/app/api/kiosk/timer/route.ts`
+  - Added `src/app/kiosk/page.tsx` as the shared-station timing UI with PIN unlock, department default/override, active timer state, searchable parts, and explicit switch handling.
+- Order detail / navigation
+  - Updated `src/app/api/orders/[id]/route.ts` and `src/modules/orders/orders.service.ts` to return `permissions.canUseTimerControls`.
+  - Updated `src/app/orders/[id]/page.tsx` to hide timer controls for kiosk-enabled machinists while keeping timer summaries, notes, files, checklist, and log visible.
+  - Added a `Kiosk` nav link in `src/components/AppNav.tsx` for machinists/admins.
+- Focused tests
+  - Extended `src/modules/time/__tests__/time.service.test.ts` for one-active-timer-total semantics and reporting summary coverage.
+  - Added `src/modules/kiosk/__tests__/kiosk.service.test.ts`.
+
+### Files touched
+- `prisma/schema.prisma`
+- `prisma/migrations/20260410174437_kiosk_user_timing_v1/migration.sql`
+- `src/lib/zod.ts`
+- `src/lib/kiosk-session.ts`
+- `src/app/admin/users/page.tsx`
+- `src/app/admin/users/client.tsx`
+- `src/app/api/admin/users/route.ts`
+- `src/app/api/admin/users/[id]/route.ts`
+- `src/app/api/orders/[id]/route.ts`
+- `src/app/api/timer/start/route.ts`
+- `src/app/api/kiosk/unlock/route.ts`
+- `src/app/api/kiosk/session/route.ts`
+- `src/app/api/kiosk/lock/route.ts`
+- `src/app/api/kiosk/parts/route.ts`
+- `src/app/api/kiosk/timer/route.ts`
+- `src/app/kiosk/page.tsx`
+- `src/app/orders/[id]/page.tsx`
+- `src/components/AppNav.tsx`
+- `src/modules/orders/orders.service.ts`
+- `src/modules/time/time.service.ts`
+- `src/modules/time/__tests__/time.service.test.ts`
+- `src/modules/users/users.repo.ts`
+- `src/modules/kiosk/kiosk.schema.ts`
+- `src/modules/kiosk/kiosk.service.ts`
+- `src/modules/kiosk/__tests__/kiosk.service.test.ts`
+- `src/repos/users.ts`
+- `src/repos/orders.ts`
+- `src/repos/mock/seed.ts`
+- `src/repos/mock/users.ts`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx prisma migrate dev --name kiosk_user_timing_v1`
+- `npx eslint --ext .ts,.tsx -- "src/app/kiosk/page.tsx" "src/app/api/kiosk/unlock/route.ts" "src/app/api/kiosk/session/route.ts" "src/app/api/kiosk/lock/route.ts" "src/app/api/kiosk/parts/route.ts" "src/app/api/kiosk/timer/route.ts" "src/app/api/orders/[id]/route.ts" "src/app/api/timer/start/route.ts" "src/app/orders/[id]/page.tsx" "src/components/AppNav.tsx" "src/modules/kiosk/kiosk.service.ts" "src/modules/kiosk/kiosk.schema.ts" "src/modules/time/time.service.ts" "src/modules/users/users.repo.ts" "src/repos/users.ts" "src/repos/mock/users.ts" "src/repos/mock/seed.ts" "src/modules/time/__tests__/time.service.test.ts" "src/modules/kiosk/__tests__/kiosk.service.test.ts"`
+- `npm run test -- src/modules/time/__tests__/time.service.test.ts src/modules/kiosk/__tests__/kiosk.service.test.ts`
+
+### Verification evidence
+- Migration applied successfully and created `20260410174437_kiosk_user_timing_v1`.
+- Targeted ESLint passed.
+- Focused kiosk/time tests passed (`11/11` total).
+- Vitest still required an outside-sandbox rerun because sandboxed esbuild hit Windows `spawn EPERM`.
+- Prisma generate during migration hit a Windows file-lock `EPERM` while renaming the query engine DLL, but the migration itself completed and the focused checks passed afterward.
+
+### Follow-up assumptions / caveats
+- Kiosk timing is intentionally PIN-based and cookie-scoped, separate from normal NextAuth browser sessions.
+- `/orders/[id]` remains the review surface for kiosk-enabled machinists, but timing must now happen on `/kiosk`.
+- The older 2026-04-07 “one active timer per `(user, department)`” decision is now superseded by one active timer total per worker.
+
 ## Session Handoff - 2026-04-10 (Order-detail layout shift for part-heavy orders)
 
 Goal (1 sentence): Give the full left side of `/orders/[id]` to the parts list, move timer/submit controls into the top of the right-side detail area, and remove the admin order-status override block from this screen.

--- a/prisma/migrations/20260410174437_kiosk_user_timing_v1/migration.sql
+++ b/prisma/migrations/20260410174437_kiosk_user_timing_v1/migration.sql
@@ -1,0 +1,23 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_User" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "email" TEXT NOT NULL,
+    "name" TEXT,
+    "role" TEXT NOT NULL DEFAULT 'MACHINIST',
+    "active" BOOLEAN NOT NULL DEFAULT true,
+    "kioskEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "kioskPinHash" TEXT,
+    "primaryDepartmentId" TEXT,
+    "passwordHash" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "User_primaryDepartmentId_fkey" FOREIGN KEY ("primaryDepartmentId") REFERENCES "Department" ("id") ON DELETE SET NULL ON UPDATE CASCADE
+);
+INSERT INTO "new_User" ("active", "createdAt", "email", "id", "name", "passwordHash", "role", "updatedAt") SELECT "active", "createdAt", "email", "id", "name", "passwordHash", "role", "updatedAt" FROM "User";
+DROP TABLE "User";
+ALTER TABLE "new_User" RENAME TO "User";
+CREATE UNIQUE INDEX "User_email_key" ON "User"("email");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -13,6 +13,9 @@ model User {
   name         String?
   role         String  @default("MACHINIST")
   active       Boolean @default(true)
+  kioskEnabled Boolean @default(false)
+  kioskPinHash String?
+  primaryDepartmentId String?
   // Credentials provider (nullable)
   passwordHash String?
 
@@ -32,6 +35,7 @@ model User {
   assignedPartWork     OrderPartAssignment[]    @relation("PartAssignmentAssignedBy")
   instructionReceipts  PartInstructionReceipt[]
   repeatOrderTemplates RepeatOrderTemplate[]    @relation("RepeatOrderTemplateCreatedBy")
+  primaryDepartment    Department?              @relation("UserPrimaryDepartment", fields: [primaryDepartmentId], references: [id])
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -325,6 +329,7 @@ model Department {
   currentParts               OrderPart[]
   instructionReceipts        PartInstructionReceipt[]
   repeatOrderTemplateCharges RepeatOrderTemplateCharge[]
+  primaryUsers               User[]                      @relation("UserPrimaryDepartment")
   createdAt                  DateTime                    @default(now())
   updatedAt                  DateTime                    @updatedAt
 }

--- a/src/app/admin/users/client.tsx
+++ b/src/app/admin/users/client.tsx
@@ -32,7 +32,12 @@ interface Item {
   email?: string;
   role?: string;
   active?: boolean;
+  kioskEnabled?: boolean;
+  primaryDepartmentId?: string | null;
+  primaryDepartment?: { id: string; name: string } | null;
 }
+
+type DepartmentOption = { id: string; name: string };
 
 type DialogState = { mode: 'create' | 'edit'; data?: Item } | null;
 
@@ -41,11 +46,15 @@ export default function Client({ initial }: { initial: any }) {
   const [nextCursor, setNextCursor] = useState<string | null>(initial.nextCursor ?? null);
   const [query, setQuery] = useState('');
   const [dialog, setDialog] = useState<DialogState>(null);
+  const [departments, setDepartments] = useState<DepartmentOption[]>([]);
   const [form, setForm] = useState({
     name: '',
     email: '',
     role: 'MACHINIST',
     active: 'true',
+    kioskEnabled: 'false',
+    primaryDepartmentId: '',
+    kioskPin: '',
     password: '',
     confirmPassword: '',
   });
@@ -54,17 +63,40 @@ export default function Client({ initial }: { initial: any }) {
   const isAdmin = canAccessAdmin(user ?? undefined);
 
   useEffect(() => {
+    if (!isAdmin) return;
+    fetchJson<any>('/api/admin/departments')
+      .then((data) => {
+        const next = Array.isArray(data?.items) ? data.items : [];
+        setDepartments(next.map((item: any) => ({ id: item.id, name: item.name })));
+      })
+      .catch(() => setDepartments([]));
+  }, [isAdmin]);
+
+  useEffect(() => {
     if (dialog?.mode === 'edit' && dialog.data) {
       setForm({
         name: dialog.data.name ?? '',
         email: dialog.data.email ?? '',
         role: dialog.data.role ?? 'MACHINIST',
         active: dialog.data.active ? 'true' : 'false',
+        kioskEnabled: dialog.data.kioskEnabled ? 'true' : 'false',
+        primaryDepartmentId: dialog.data.primaryDepartmentId ?? '',
+        kioskPin: '',
         password: '',
         confirmPassword: '',
       });
     } else if (dialog?.mode === 'create') {
-      setForm({ name: '', email: '', role: 'MACHINIST', active: 'true', password: '', confirmPassword: '' });
+      setForm({
+        name: '',
+        email: '',
+        role: 'MACHINIST',
+        active: 'true',
+        kioskEnabled: 'false',
+        primaryDepartmentId: '',
+        kioskPin: '',
+        password: '',
+        confirmPassword: '',
+      });
     }
   }, [dialog]);
 
@@ -89,6 +121,9 @@ export default function Client({ initial }: { initial: any }) {
         email: form.email,
         role: form.role,
         active: form.active === 'true',
+        kioskEnabled: form.kioskEnabled === 'true',
+        primaryDepartmentId: form.primaryDepartmentId || undefined,
+        kioskPin: form.kioskPin || undefined,
         ...(form.password ? { password: form.password } : {}),
       };
 
@@ -144,6 +179,12 @@ export default function Client({ initial }: { initial: any }) {
         key: 'active',
         header: 'Active',
         render: (value: any) => (value ? 'true' : 'false'),
+      },
+      {
+        key: 'kioskEnabled',
+        header: 'Kiosk',
+        render: (value: any, row: Item) =>
+          value ? `Yes${row.primaryDepartment?.name ? ` · ${row.primaryDepartment.name}` : ''}` : 'No',
       },
     ],
     []
@@ -245,6 +286,60 @@ export default function Client({ initial }: { initial: any }) {
                   </SelectContent>
                 </Select>
               </div>
+            </div>
+            <div className="grid gap-2 md:grid-cols-2">
+              <div className="grid gap-2">
+                <Label htmlFor="userKioskEnabled">Kiosk timing</Label>
+                <Select
+                  value={form.kioskEnabled}
+                  onValueChange={(value) => setForm((prev) => ({ ...prev, kioskEnabled: value }))}
+                >
+                  <SelectTrigger id="userKioskEnabled">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="false">disabled</SelectItem>
+                    <SelectItem value="true">enabled</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="userPrimaryDepartment">Primary department</Label>
+                <Select
+                  value={form.primaryDepartmentId || '__none__'}
+                  onValueChange={(value) =>
+                    setForm((prev) => ({
+                      ...prev,
+                      primaryDepartmentId: value === '__none__' ? '' : value,
+                    }))
+                  }
+                >
+                  <SelectTrigger id="userPrimaryDepartment">
+                    <SelectValue placeholder="Select department" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">No default department</SelectItem>
+                    {departments.map((department) => (
+                      <SelectItem key={department.id} value={department.id}>
+                        {department.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="userKioskPin">{dialog?.mode === 'edit' ? 'New kiosk PIN' : 'Kiosk PIN'}</Label>
+              <Input
+                id="userKioskPin"
+                inputMode="numeric"
+                value={form.kioskPin}
+                onChange={(e) => setForm((prev) => ({ ...prev, kioskPin: e.target.value.replace(/\D+/g, '') }))}
+                placeholder={dialog?.mode === 'edit' ? 'Leave blank to keep current PIN' : '4 to 8 digits'}
+              />
+              <p className="text-xs text-muted-foreground">
+                Required when kiosk timing is enabled. PINs must be 4 to 8 digits.
+              </p>
             </div>
             <div className="grid gap-2 md:grid-cols-2">
               <div className="grid gap-2">

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -7,8 +7,19 @@ export const dynamic = 'force-dynamic';
 
 export default async function Page() {
   // Load initial data directly on the server using Prisma to avoid SSR fetch issues
-  const itemsRaw = await prisma.user.findMany({ orderBy: { id: 'asc' }, take: 20 });
-  const items = itemsRaw.map(({ passwordHash, ...rest }) => rest);
+  const itemsRaw = await prisma.user.findMany({
+    orderBy: { id: 'asc' },
+    take: 20,
+    include: {
+      primaryDepartment: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+  const items = itemsRaw.map(({ passwordHash, kioskPinHash, ...rest }) => rest);
   const initial = { items, nextCursor: null };
   return (
     <div className="p-4 text-neutral-100">

--- a/src/app/api/admin/users/[id]/route.ts
+++ b/src/app/api/admin/users/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getServerAuthSession } from '@/lib/auth-session';
 import { canAccessAdmin } from '@/lib/rbac';
 import { hash } from 'bcryptjs';
-import { updateUser } from '@/repos/users';
+import { findUserById, updateUser } from '@/repos/users';
 import { UserPatch } from '@/lib/zod';
 
 async function requireAdmin(): Promise<NextResponse | null> {
@@ -20,9 +20,23 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   const body = await req.json();
   const parsed = UserPatch.safeParse(body);
   if (!parsed.success) return NextResponse.json({ error: parsed.error.message }, { status: 400 });
-  const { password, ...data } = parsed.data as any;
+  const existing = await findUserById(id);
+  if (!existing) return NextResponse.json({ error: 'User not found.' }, { status: 404 });
+  const { password, kioskPin, kioskEnabled, primaryDepartmentId, ...data } = parsed.data as any;
+  const nextKioskEnabled = kioskEnabled ?? existing.kioskEnabled;
+  const nextPrimaryDepartmentId =
+    primaryDepartmentId !== undefined ? primaryDepartmentId || null : existing.primaryDepartmentId ?? null;
+  if (nextKioskEnabled && !nextPrimaryDepartmentId) {
+    return NextResponse.json({ error: 'Primary department is required when kiosk access is enabled.' }, { status: 400 });
+  }
+  if (nextKioskEnabled && !kioskPin && !existing.kioskPinHash) {
+    return NextResponse.json({ error: 'Kiosk PIN is required before kiosk access can be enabled.' }, { status: 400 });
+  }
   const item = await updateUser(id, {
     ...data,
+    ...(kioskEnabled !== undefined ? { kioskEnabled } : {}),
+    ...(primaryDepartmentId !== undefined ? { primaryDepartmentId: primaryDepartmentId || null } : {}),
+    ...(kioskPin ? { kioskPinHash: await hash(kioskPin, 10) } : {}),
     ...(password ? { passwordHash: await hash(password, 10) } : {}),
   });
   return NextResponse.json({ ok: true, item });

--- a/src/app/api/admin/users/route.ts
+++ b/src/app/api/admin/users/route.ts
@@ -42,9 +42,18 @@ export async function POST(req: NextRequest) {
   const body = await req.json();
   const parsed = UserUpsert.safeParse(body);
   if (!parsed.success) return NextResponse.json({ error: parsed.error.message }, { status: 400 });
-  const { password, ...data } = parsed.data as any;
+  const { password, kioskPin, kioskEnabled, primaryDepartmentId, ...data } = parsed.data as any;
+  if (kioskEnabled && !primaryDepartmentId) {
+    return NextResponse.json({ error: 'Primary department is required when kiosk access is enabled.' }, { status: 400 });
+  }
+  if (kioskEnabled && !kioskPin) {
+    return NextResponse.json({ error: 'Kiosk PIN is required when kiosk access is enabled.' }, { status: 400 });
+  }
   const item = await createUser({
     ...data,
+    kioskEnabled: Boolean(kioskEnabled),
+    primaryDepartmentId: primaryDepartmentId || null,
+    ...(kioskPin ? { kioskPinHash: await hash(kioskPin, 10) } : {}),
     ...(password ? { passwordHash: await hash(password, 10) } : {}),
   });
   return NextResponse.json({ ok: true, item });

--- a/src/app/api/kiosk/_lib.ts
+++ b/src/app/api/kiosk/_lib.ts
@@ -1,0 +1,11 @@
+import { readKioskSessionUserId, KIOSK_SESSION_COOKIE } from '@/lib/kiosk-session';
+
+export function getKioskSessionUserId(req: Request) {
+  const cookieHeader = req.headers.get('cookie') ?? '';
+  const rawCookie = cookieHeader
+    .split(';')
+    .map((value) => value.trim())
+    .find((value) => value.startsWith(`${KIOSK_SESSION_COOKIE}=`))
+    ?.slice(KIOSK_SESSION_COOKIE.length + 1);
+  return readKioskSessionUserId(rawCookie);
+}

--- a/src/app/api/kiosk/lock/route.ts
+++ b/src/app/api/kiosk/lock/route.ts
@@ -1,0 +1,8 @@
+import { NextResponse } from 'next/server';
+import { KIOSK_SESSION_COOKIE } from '@/lib/kiosk-session';
+
+export async function POST() {
+  const response = NextResponse.json({ ok: true });
+  response.cookies.set(KIOSK_SESSION_COOKIE, '', { path: '/', maxAge: 0 });
+  return response;
+}

--- a/src/app/api/kiosk/parts/route.ts
+++ b/src/app/api/kiosk/parts/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import { getKioskSessionUserId } from '@/app/api/kiosk/_lib';
+import { KioskPartsSearchInput } from '@/modules/kiosk/kiosk.schema';
+import { searchKioskParts } from '@/modules/kiosk/kiosk.service';
+
+export async function GET(req: Request) {
+  const userId = getKioskSessionUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk locked.' }, { status: 401 });
+  }
+
+  const { searchParams } = new URL(req.url);
+  const parsed = KioskPartsSearchInput.safeParse({
+    departmentId: searchParams.get('departmentId') ?? '',
+    q: searchParams.get('q') ?? '',
+    take: searchParams.get('take') ?? 30,
+  });
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const result = await searchKioskParts({
+    userId,
+    departmentId: parsed.data.departmentId,
+    query: parsed.data.q,
+    take: parsed.data.take,
+  });
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/session/route.ts
+++ b/src/app/api/kiosk/session/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getKioskSessionUserId } from '@/app/api/kiosk/_lib';
+import { getKioskSessionContext } from '@/modules/kiosk/kiosk.service';
+
+export async function GET(req: Request) {
+  const userId = getKioskSessionUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk locked.' }, { status: 401 });
+  }
+
+  const result = await getKioskSessionContext(userId);
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/timer/finish/route.ts
+++ b/src/app/api/kiosk/timer/finish/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getKioskSessionUserId } from '@/app/api/kiosk/_lib';
+import { finishKioskTimer } from '@/modules/kiosk/kiosk.service';
+
+export async function POST(req: Request) {
+  const userId = getKioskSessionUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk locked.' }, { status: 401 });
+  }
+
+  const result = await finishKioskTimer(userId);
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/timer/pause/route.ts
+++ b/src/app/api/kiosk/timer/pause/route.ts
@@ -1,0 +1,17 @@
+import { NextResponse } from 'next/server';
+import { getKioskSessionUserId } from '@/app/api/kiosk/_lib';
+import { pauseKioskTimer } from '@/modules/kiosk/kiosk.service';
+
+export async function POST(req: Request) {
+  const userId = getKioskSessionUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk locked.' }, { status: 401 });
+  }
+
+  const result = await pauseKioskTimer(userId);
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/timer/route.ts
+++ b/src/app/api/kiosk/timer/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { KIOSK_SESSION_COOKIE, readKioskSessionUserId } from '@/lib/kiosk-session';
+import { KioskTimerStart } from '@/modules/kiosk/kiosk.schema';
+import {
+  finishKioskWorkerTimer,
+  getKioskWorkerSession,
+  pauseKioskWorkerTimer,
+  startKioskWorkerTimer,
+} from '@/modules/kiosk/kiosk.service';
+
+function readUserId(req: NextRequest) {
+  return readKioskSessionUserId(req.cookies.get(KIOSK_SESSION_COOKIE)?.value);
+}
+
+export async function GET(req: NextRequest) {
+  const userId = readUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk is locked.' }, { status: 401 });
+  }
+
+  const result = await getKioskWorkerSession(userId);
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}
+
+export async function POST(req: NextRequest) {
+  const userId = readUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk is locked.' }, { status: 401 });
+  }
+
+  const body = await req.json().catch(() => null);
+  const action = typeof body?.action === 'string' ? body.action.trim().toLowerCase() : 'start';
+
+  if (action === 'pause') {
+    const result = await pauseKioskWorkerTimer(userId);
+    if (result.ok === false) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+    return NextResponse.json(result.data);
+  }
+
+  if (action === 'finish') {
+    const result = await finishKioskWorkerTimer(userId);
+    if (result.ok === false) {
+      return NextResponse.json({ error: result.error }, { status: result.status });
+    }
+    return NextResponse.json(result.data);
+  }
+
+  const parsed = KioskTimerStart.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const result = await startKioskWorkerTimer({
+    userId,
+    orderId: parsed.data.orderId,
+    partId: parsed.data.partId,
+    departmentId: parsed.data.departmentId,
+    switchAction: parsed.data.switchAction,
+  });
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/timer/start/route.ts
+++ b/src/app/api/kiosk/timer/start/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { getKioskSessionUserId } from '@/app/api/kiosk/_lib';
+import { KioskTimerStartInput } from '@/modules/kiosk/kiosk.schema';
+import { startKioskTimer } from '@/modules/kiosk/kiosk.service';
+
+export async function POST(req: Request) {
+  const userId = getKioskSessionUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk locked.' }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = KioskTimerStartInput.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const result = await startKioskTimer({ userId, ...parsed.data });
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/timer/switch/route.ts
+++ b/src/app/api/kiosk/timer/switch/route.ts
@@ -1,0 +1,24 @@
+import { NextResponse } from 'next/server';
+import { getKioskSessionUserId } from '@/app/api/kiosk/_lib';
+import { KioskTimerSwitchInput } from '@/modules/kiosk/kiosk.schema';
+import { switchKioskTimer } from '@/modules/kiosk/kiosk.service';
+
+export async function POST(req: Request) {
+  const userId = getKioskSessionUserId(req);
+  if (!userId) {
+    return NextResponse.json({ error: 'Kiosk locked.' }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = KioskTimerSwitchInput.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const result = await switchKioskTimer({ userId, ...parsed.data });
+  if (result.ok === false) {
+    return NextResponse.json({ error: result.error }, { status: result.status });
+  }
+
+  return NextResponse.json(result.data);
+}

--- a/src/app/api/kiosk/unlock/route.ts
+++ b/src/app/api/kiosk/unlock/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { createKioskSessionValue, kioskSessionCookieOptions, KIOSK_SESSION_COOKIE } from '@/lib/kiosk-session';
+import { KioskUnlockInput } from '@/modules/kiosk/kiosk.schema';
+import { getKioskSessionContext, unlockKioskByPin, unlockKioskByWorkerPin } from '@/modules/kiosk/kiosk.service';
+
+export async function POST(req: Request) {
+  const json = await req.json().catch(() => null);
+  const parsed = KioskUnlockInput.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const unlockResult = parsed.data.userId
+    ? await unlockKioskByWorkerPin({ userId: parsed.data.userId, pin: parsed.data.pin })
+    : await unlockKioskByPin(parsed.data.pin);
+  if (unlockResult.ok === false) {
+    return NextResponse.json({ error: unlockResult.error }, { status: unlockResult.status });
+  }
+
+  const workerId = String((unlockResult.data.worker as any).id ?? '');
+  const contextResult = await getKioskSessionContext(workerId);
+  if (contextResult.ok === false) {
+    return NextResponse.json({ error: contextResult.error }, { status: contextResult.status });
+  }
+
+  const response = NextResponse.json(contextResult.data);
+  response.cookies.set(KIOSK_SESSION_COOKIE, createKioskSessionValue(workerId), kioskSessionCookieOptions);
+  return response;
+}

--- a/src/app/api/orders/[id]/route.ts
+++ b/src/app/api/orders/[id]/route.ts
@@ -4,17 +4,24 @@ import { getServerAuthSession } from '@/lib/auth-session';
 import { canAccessAdmin } from '@/lib/rbac';
 import { OrderUpdate } from '@/modules/orders/orders.schema';
 import { getOrderDetails, updateOrderDetails } from '@/modules/orders/orders.service';
+import { findUserById } from '@/repos/users';
 
 export async function GET(req: Request, { params }: { params: Promise<{ id: string }> }) {
   const session = await getServerAuthSession();
   if (!session) return new NextResponse('Unauthorized', { status: 401 });
   const user = (session as any).user;
   const isAdmin = canAccessAdmin(user);
+  const userId = typeof user?.id === 'string' ? user.id : '';
+  const currentUser = userId ? await findUserById(userId) : null;
+  const canUseTimerControls = !(
+    currentUser?.role === 'MACHINIST' &&
+    currentUser?.kioskEnabled === true
+  );
 
   const { id } = await params;
   if (!id) return NextResponse.json({ error: 'Missing id' }, { status: 400 });
 
-  const result = await getOrderDetails(id, isAdmin);
+  const result = await getOrderDetails(id, { isAdmin, canUseTimerControls });
   if (result.ok === false) {
     return NextResponse.json({ error: result.error }, { status: result.status });
   }

--- a/src/app/api/timer/start/route.ts
+++ b/src/app/api/timer/start/route.ts
@@ -11,7 +11,7 @@ import {
   syncOrderWorkflowStatus,
 } from '@/modules/orders/orders.service';
 import { TimeEntryStart } from '@/modules/time/time.schema';
-import { getActiveTimeEntries, getActiveTimeEntry, startTimeEntryWithConflict } from '@/modules/time/time.service';
+import { getActiveTimeEntry, startTimeEntryWithConflict } from '@/modules/time/time.service';
 
 export async function POST(req: NextRequest) {
   const session = await getServerAuthSession();
@@ -66,15 +66,7 @@ export async function POST(req: NextRequest) {
   });
   if (result.ok === false) {
     if (result.status === 409) {
-      const activeEntriesResult = await getActiveTimeEntries(userId);
-      if (activeEntriesResult.ok === false) {
-        return NextResponse.json({ error: activeEntriesResult.error }, { status: activeEntriesResult.status });
-      }
-      const matchingDepartmentEntry =
-        activeEntriesResult.data.entries.find((entry) => entry.departmentId === departmentId) ?? null;
-      const activeResult = matchingDepartmentEntry
-        ? ({ ok: true, data: { entry: matchingDepartmentEntry } } as const)
-        : await getActiveTimeEntry(userId);
+      const activeResult = await getActiveTimeEntry(userId);
       if (activeResult.ok === false) {
         return NextResponse.json({ error: activeResult.error }, { status: activeResult.status });
       }

--- a/src/app/kiosk/KioskClient.tsx
+++ b/src/app/kiosk/KioskClient.tsx
@@ -1,0 +1,382 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { Lock, PauseCircle, Play, Search, Square, UserCircle2 } from 'lucide-react';
+import { Button } from '@/components/ui/Button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/Card';
+import { Input } from '@/components/ui/Input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+function formatDuration(seconds: number) {
+  const clamped = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const secs = clamped % 60;
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${pad(hours)}:${pad(minutes)}:${pad(secs)}`;
+}
+
+export default function KioskClient() {
+  const [session, setSession] = useState<any | null>(null);
+  const [pin, setPin] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [unlocking, setUnlocking] = useState(false);
+  const [acting, setActing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [departmentId, setDepartmentId] = useState('');
+  const [query, setQuery] = useState('');
+  const [parts, setParts] = useState<any[]>([]);
+  const [selectedPartId, setSelectedPartId] = useState('');
+  const [conflict, setConflict] = useState<any | null>(null);
+  const [nowMs, setNowMs] = useState(() => Date.now());
+
+  const selectedPart = useMemo(() => parts.find((part) => part.id === selectedPartId) ?? null, [parts, selectedPartId]);
+
+  async function loadSession() {
+    setLoading(true);
+    try {
+      const res = await fetch('/api/kiosk/session', { credentials: 'include' });
+      if (!res.ok) {
+        setSession(null);
+        setParts([]);
+        return;
+      }
+      const data = await res.json();
+      setSession(data);
+      setDepartmentId(data.defaultDepartmentId ?? '');
+      setError(null);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  const loadParts = useCallback(async (nextDepartmentId: string, nextQuery: string) => {
+    if (!session || !nextDepartmentId) {
+      setParts([]);
+      return;
+    }
+    const params = new URLSearchParams({ departmentId: nextDepartmentId, q: nextQuery });
+    const res = await fetch(`/api/kiosk/parts?${params.toString()}`, { credentials: 'include' });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+      setError(typeof data?.error === 'string' ? data.error : 'Failed to load parts.');
+      setParts([]);
+      return;
+    }
+    setParts(Array.isArray(data?.items) ? data.items : []);
+  }, [session]);
+
+  useEffect(() => {
+    void loadSession();
+  }, []);
+
+  useEffect(() => {
+    if (!session || !departmentId) return;
+    void loadParts(departmentId, query);
+  }, [session, departmentId, query, loadParts]);
+
+  useEffect(() => {
+    const timer = session?.activeTimer ? window.setInterval(() => setNowMs(Date.now()), 1000) : null;
+    return () => {
+      if (timer) window.clearInterval(timer);
+    };
+  }, [session?.activeTimer]);
+
+  async function handleUnlock() {
+    setUnlocking(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/kiosk/unlock', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pin }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setError(typeof data?.error === 'string' ? data.error : 'Failed to unlock kiosk.');
+        return;
+      }
+      setSession(data);
+      setDepartmentId(data.defaultDepartmentId ?? '');
+      setPin('');
+      setConflict(null);
+    } catch {
+      setError('Failed to unlock kiosk.');
+    } finally {
+      setUnlocking(false);
+    }
+  }
+
+  async function handleLock() {
+    setActing(true);
+    await fetch('/api/kiosk/lock', { method: 'POST', credentials: 'include' });
+    setSession(null);
+    setParts([]);
+    setSelectedPartId('');
+    setConflict(null);
+    setActing(false);
+  }
+
+  async function handleStart() {
+    if (!selectedPart || !departmentId) return;
+    setActing(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/kiosk/timer/start', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orderId: selectedPart.orderId,
+          partId: selectedPart.id,
+          departmentId,
+        }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        const payload = data?.error;
+        if (res.status === 409 && payload?.requiredAction === 'switch_confirmation') {
+          setConflict({ ...payload, target: selectedPart, departmentId });
+          return;
+        }
+        setError(typeof payload === 'string' ? payload : typeof data?.error === 'string' ? data.error : 'Failed to start timer.');
+        return;
+      }
+      await loadSession();
+      await loadParts(departmentId, query);
+    } catch {
+      setError('Failed to start timer.');
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function handleAction(action: 'pause' | 'finish') {
+    setActing(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/kiosk/timer/${action}`, { method: 'POST', credentials: 'include' });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setError(typeof data?.error === 'string' ? data.error : `Failed to ${action} timer.`);
+        return;
+      }
+      await loadSession();
+      await loadParts(departmentId, query);
+    } catch {
+      setError(`Failed to ${action} timer.`);
+    } finally {
+      setActing(false);
+    }
+  }
+
+  async function handleSwitch(stopMode: 'pause' | 'finish') {
+    if (!conflict?.target) return;
+    setActing(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/kiosk/timer/switch', {
+        method: 'POST',
+        credentials: 'include',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          orderId: conflict.target.orderId,
+          partId: conflict.target.id,
+          departmentId: conflict.departmentId,
+          stopMode,
+        }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        setError(typeof data?.error === 'string' ? data.error : 'Failed to switch timer.');
+        return;
+      }
+      setConflict(null);
+      await loadSession();
+      await loadParts(departmentId, query);
+    } catch {
+      setError('Failed to switch timer.');
+    } finally {
+      setActing(false);
+    }
+  }
+
+  if (loading) {
+    return <div className="p-6 text-sm text-muted-foreground">Loading kiosk…</div>;
+  }
+
+  if (!session) {
+    return (
+      <div className="min-h-screen bg-background p-6">
+        <div className="mx-auto flex min-h-[70vh] max-w-xl items-center">
+          <Card className="w-full">
+            <CardHeader>
+              <CardTitle className="text-2xl">Shop Kiosk</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                Enter your PIN to punch time. Use the normal order page to review notes, files, and checklist items.
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="kiosk-pin">PIN</Label>
+                <Input id="kiosk-pin" type="password" inputMode="numeric" value={pin} onChange={(e) => setPin(e.target.value)} />
+              </div>
+              {error ? <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
+              <Button className="w-full" disabled={unlocking || pin.trim().length < 4} onClick={() => void handleUnlock()}>
+                {unlocking ? 'Unlocking…' : 'Unlock kiosk'}
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
+
+  const activeTimer = session.activeTimer;
+  const activeElapsed = activeTimer?.startedAt
+    ? Math.max(0, Math.floor((nowMs - new Date(activeTimer.startedAt).getTime()) / 1000))
+    : 0;
+
+  return (
+    <div className="min-h-screen bg-background p-6">
+      <div className="mx-auto grid max-w-7xl gap-6 lg:grid-cols-[360px_minmax(0,1fr)]">
+        <Card className="h-fit">
+          <CardHeader className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <UserCircle2 className="h-5 w-5 text-primary" />
+                <div>
+                  <div className="text-sm font-semibold text-foreground">{session.worker.name || session.worker.email}</div>
+                  <div className="text-xs text-muted-foreground">{session.worker.primaryDepartment?.name || 'No default department'}</div>
+                </div>
+              </div>
+              <Button variant="outline" size="sm" disabled={acting} onClick={() => void handleLock()}>
+                <Lock className="mr-2 h-4 w-4" />
+                Lock
+              </Button>
+            </div>
+            <div className="space-y-2">
+              <Label>Department</Label>
+              <Select value={departmentId} onValueChange={setDepartmentId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Choose department" />
+                </SelectTrigger>
+                <SelectContent>
+                  {(Array.isArray(session.departments) ? session.departments : []).map((department: any) => (
+                    <SelectItem key={department.id} value={department.id}>
+                      {department.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="kiosk-search">Part search</Label>
+              <div className="relative">
+                <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input id="kiosk-search" className="pl-9" value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Order, customer, or part" />
+              </div>
+            </div>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <div className="max-h-[60vh] space-y-2 overflow-auto pr-1">
+              {parts.length ? parts.map((part) => (
+                <button
+                  key={part.id}
+                  type="button"
+                  onClick={() => setSelectedPartId(part.id)}
+                  className={`w-full rounded-lg border p-3 text-left transition ${selectedPartId === part.id ? 'border-primary bg-primary/10' : 'border-border/60 bg-muted/10 hover:bg-muted/20'}`}
+                >
+                  <div className="flex items-center justify-between gap-3">
+                    <div className="font-medium text-foreground">{part.partNumber || 'Unnamed part'}</div>
+                    <div className="text-xs text-muted-foreground">{part.order?.orderNumber}</div>
+                  </div>
+                  <div className="mt-1 text-xs text-muted-foreground">
+                    {part.order?.customer?.name || 'No customer'} • Qty {part.quantity ?? 0}
+                  </div>
+                </button>
+              )) : (
+                <div className="rounded-lg border border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                  No open parts found for this department.
+                </div>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <CardTitle>Timing Controls</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {activeTimer ? (
+              <div className="rounded-lg border border-emerald-500/30 bg-emerald-500/10 p-4">
+                <div className="text-sm font-medium text-foreground">
+                  Active: {activeTimer.order?.orderNumber || 'Order'} / {activeTimer.part?.partNumber || activeTimer.partId || 'Part'}
+                </div>
+                <div className="mt-1 text-sm text-muted-foreground">
+                  {activeTimer.departmentName || activeTimer.departmentId || 'No department'} • {formatDuration(activeElapsed)}
+                </div>
+                <div className="mt-4 grid gap-3 sm:grid-cols-2">
+                  <Button variant="outline" size="lg" className="justify-center gap-2" disabled={acting} onClick={() => void handleAction('pause')}>
+                    <PauseCircle className="h-5 w-5" />
+                    Pause
+                  </Button>
+                  <Button size="lg" className="justify-center gap-2" disabled={acting} onClick={() => void handleAction('finish')}>
+                    <Square className="h-5 w-5" />
+                    Stop
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-border/60 bg-muted/10 p-4 text-sm text-muted-foreground">
+                No active timer. Select a part and start work.
+              </div>
+            )}
+
+            <div className="rounded-lg border border-border/60 bg-background/70 p-4">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">Selected part</div>
+              <div className="mt-1 text-lg font-semibold text-foreground">{selectedPart?.partNumber || 'No part selected'}</div>
+              <div className="mt-1 text-sm text-muted-foreground">
+                {selectedPart ? `${selectedPart.order?.orderNumber || 'Order'} • ${selectedPart.order?.customer?.name || 'No customer'}` : 'Pick a part on the left.'}
+              </div>
+              {selectedPart ? (
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <Button size="lg" className="gap-2" disabled={acting || !departmentId} onClick={() => void handleStart()}>
+                    <Play className="h-5 w-5" />
+                    Start timer
+                  </Button>
+                  <Button asChild size="lg" variant="outline">
+                    <Link href={`/orders/${selectedPart.orderId}?part=${selectedPart.id}`}>Open order details</Link>
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+
+            {conflict ? (
+              <div className="rounded-lg border border-amber-500/40 bg-amber-500/10 p-4">
+                <div className="text-sm font-medium text-foreground">
+                  Timer already running on {conflict.activeOrder?.orderNumber || 'another order'}
+                  {conflict.activePart?.partNumber ? ` / ${conflict.activePart.partNumber}` : ''}
+                </div>
+                <div className="mt-1 text-sm text-muted-foreground">
+                  {conflict.activeEntry?.departmentName || conflict.activeEntry?.departmentId || 'Unknown department'} • {formatDuration(conflict.elapsedSeconds ?? 0)}
+                </div>
+                <div className="mt-4 flex flex-wrap gap-3">
+                  <Button variant="outline" disabled={acting} onClick={() => void handleSwitch('pause')}>Pause & switch</Button>
+                  <Button disabled={acting} onClick={() => void handleSwitch('finish')}>Stop & switch</Button>
+                  <Button variant="ghost" disabled={acting} onClick={() => setConflict(null)}>Cancel</Button>
+                </div>
+              </div>
+            ) : null}
+
+            {error ? <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-sm text-destructive">{error}</div> : null}
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/src/app/kiosk/page.tsx
+++ b/src/app/kiosk/page.tsx
@@ -1,0 +1,5 @@
+import KioskClient from './KioskClient';
+
+export default function KioskPage() {
+  return <KioskClient />;
+}

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -61,6 +61,9 @@ type TeamUserOption = {
   email?: string | null;
   role?: string | null;
   active?: boolean | null;
+  kioskEnabled?: boolean | null;
+  primaryDepartmentId?: string | null;
+  primaryDepartment?: { id: string; name: string } | null;
 };
 type MoveDepartmentDialogState = {
   open: boolean;
@@ -92,6 +95,23 @@ type ChecklistPerformerDialogState = {
   checked: boolean;
   performerId: string;
 };
+type KioskTimerDialogMode = 'start' | 'pause' | 'finish';
+type KioskTimerDialogState = {
+  open: boolean;
+  mode: KioskTimerDialogMode;
+  workerId: string;
+  departmentId: string;
+  pin: string;
+  partId: string;
+  loading: boolean;
+  error: string | null;
+  conflict: {
+    activeEntry: any | null;
+    activeOrder: any | null;
+    activePart: any | null;
+    elapsedSeconds: number;
+  } | null;
+};
 
 const formatDuration = (seconds: number) => {
   const clamped = Math.max(0, seconds);
@@ -122,6 +142,9 @@ export default function OrderDetailPage() {
   const [activeTab, setActiveTab] = useState<PartTab>('overview');
   const [noteText, setNoteText] = useState('');
   const [canEditParts, setCanEditParts] = useState(false);
+  const [canUseTimerControls, setCanUseTimerControls] = useState(true);
+  const [kioskSession, setKioskSession] = useState<any | null>(null);
+  const [kioskSessionLoading, setKioskSessionLoading] = useState(false);
   const [partEvents, setPartEvents] = useState<any[]>([]);
   const [eventsLoading, setEventsLoading] = useState(false);
   const [timerError, setTimerError] = useState<string | null>(null);
@@ -219,6 +242,17 @@ export default function OrderDetailPage() {
   const [repeatTemplateSaving, setRepeatTemplateSaving] = useState(false);
   const [repeatTemplateError, setRepeatTemplateError] = useState<string | null>(null);
   const [savedRepeatTemplate, setSavedRepeatTemplate] = useState<{ id: string; name: string } | null>(null);
+  const [kioskTimerDialog, setKioskTimerDialog] = useState<KioskTimerDialogState>({
+    open: false,
+    mode: 'start',
+    workerId: '',
+    departmentId: '',
+    pin: '',
+    partId: '',
+    loading: false,
+    error: null,
+    conflict: null,
+  });
 
   const parts = useMemo(() => (Array.isArray(item?.parts) ? item.parts : []), [item?.parts]);
   const partIdsParam = useMemo(() => parts.map((part: any) => part.id).filter(Boolean).join(','), [parts]);
@@ -282,6 +316,11 @@ export default function OrderDetailPage() {
   const availableAssignmentUsers = useMemo(
     () => performerUsers.filter((user) => !assignedWorkerIds.has(user.id)),
     [assignedWorkerIds, performerUsers],
+  );
+  const kioskWorkers = useMemo(() => activeTeamUsers, [activeTeamUsers]);
+  const selectedKioskWorker = useMemo(
+    () => kioskWorkers.find((user) => user.id === kioskTimerDialog.workerId) ?? null,
+    [kioskTimerDialog.workerId, kioskWorkers],
   );
   const selectedChecklist = useMemo(() => {
     if (!selectedPartId) return [];
@@ -433,6 +472,7 @@ export default function OrderDetailPage() {
           : []
       );
       setCanEditParts(Boolean(data?.permissions?.canEditParts));
+      setCanUseTimerControls(Boolean(data?.permissions?.canUseTimerControls ?? true));
       setError(null);
       return data.item;
     } catch (err: any) {
@@ -487,9 +527,42 @@ export default function OrderDetailPage() {
     }
   }, [id, partIdsParam]);
 
+  const refreshKioskSession = React.useCallback(async () => {
+    if (canUseTimerControls) {
+      setKioskSession(null);
+      return null;
+    }
+
+    setKioskSessionLoading(true);
+    try {
+      const res = await fetch('/api/kiosk/session', { credentials: 'include' });
+      if (res.status === 401) {
+        setKioskSession(null);
+        return null;
+      }
+      if (!res.ok) throw res;
+      const data = await res.json().catch(() => null);
+      setKioskSession(data);
+      return data;
+    } catch {
+      setKioskSession(null);
+      return null;
+    } finally {
+      setKioskSessionLoading(false);
+    }
+  }, [canUseTimerControls]);
+
   useEffect(() => {
     load();
   }, [load]);
+
+  useEffect(() => {
+    if (canUseTimerControls) {
+      setKioskSession(null);
+      return;
+    }
+    void refreshKioskSession();
+  }, [canUseTimerControls, refreshKioskSession]);
 
   useEffect(() => {
     let active = true;
@@ -508,6 +581,15 @@ export default function OrderDetailPage() {
               email: typeof user?.email === 'string' ? user.email : null,
               role: typeof user?.role === 'string' ? user.role : null,
               active: typeof user?.active === 'boolean' ? user.active : null,
+              kioskEnabled: typeof user?.kioskEnabled === 'boolean' ? user.kioskEnabled : null,
+              primaryDepartmentId: typeof user?.primaryDepartmentId === 'string' ? user.primaryDepartmentId : null,
+              primaryDepartment:
+                user?.primaryDepartment && typeof user.primaryDepartment === 'object'
+                  ? {
+                      id: String(user.primaryDepartment.id ?? ''),
+                      name: String(user.primaryDepartment.name ?? '').trim(),
+                    }
+                  : null,
             }))
             .filter((user: TeamUserOption) => user.id.length > 0),
         );
@@ -841,6 +923,309 @@ export default function OrderDetailPage() {
     } finally {
       setTimerSaving(false);
     }
+  };
+
+  const closeKioskTimerDialog = () => {
+    setKioskTimerDialog({
+      open: false,
+      mode: 'start',
+      workerId: '',
+      departmentId: '',
+      pin: '',
+      partId: '',
+      loading: false,
+      error: null,
+      conflict: null,
+    });
+  };
+
+  const openKioskTimerDialog = (mode: KioskTimerDialogMode) => {
+    const defaultWorkerId = kioskSession?.worker?.id ?? currentUserId ?? kioskWorkers[0]?.id ?? '';
+    const defaultWorker =
+      kioskWorkers.find((user) => user.id === defaultWorkerId) ??
+      kioskWorkers[0] ??
+      null;
+    const defaultDepartmentId =
+      defaultWorker?.primaryDepartmentId ??
+      selectedTimerDepartmentId ??
+      timerDepartments[0]?.id ??
+      '';
+    setKioskTimerDialog({
+      open: true,
+      mode,
+      workerId: defaultWorkerId,
+      departmentId: defaultDepartmentId,
+      pin: '',
+      partId: selectedPartId ?? parts[0]?.id ?? '',
+      loading: false,
+      error: null,
+      conflict: null,
+    });
+  };
+
+  const unlockKioskSession = async ({ workerId, pin }: { workerId: string; pin: string }) => {
+    const res = await fetch('/api/kiosk/unlock', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      credentials: 'include',
+      body: JSON.stringify({ userId: workerId, pin }),
+    });
+    const data = await res.json().catch(() => null);
+    if (!res.ok) {
+      throw new Error(typeof data?.error === 'string' ? data.error : 'Failed to unlock kiosk.');
+    }
+    setKioskSession(data);
+    return data;
+  };
+
+  const ensureKioskSession = async ({ workerId, pin }: { workerId: string; pin: string }) => {
+    if (!workerId) {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'Choose a worker first.',
+      }));
+      return null;
+    }
+    if (!pin.trim()) {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'Enter your PIN to continue.',
+      }));
+      return null;
+    }
+
+    try {
+      return await unlockKioskSession({ workerId, pin: pin.trim() });
+    } catch (error: any) {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: error?.message || 'Failed to unlock kiosk.',
+      }));
+      return null;
+    }
+  };
+
+  const runKioskTimerAction = async (action: 'pause' | 'finish'): Promise<boolean> => {
+    setTimerSaving(true);
+    setTimerError(null);
+    try {
+      const res = await fetch(`/api/kiosk/timer/${action}`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        if (res.status === 401) {
+          setKioskSession(null);
+          openKioskTimerDialog(action);
+          setKioskTimerDialog((prev) => ({
+            ...prev,
+            error: 'Enter your PIN to continue.',
+          }));
+          return false;
+        }
+        setTimerError(typeof data?.error === 'string' ? data.error : `Failed to ${action} timer.`);
+        return false;
+      }
+      if (action === 'finish') {
+        await load();
+      }
+      await refreshTimerSummary();
+      await loadPartEvents();
+      await refreshKioskSession();
+      return true;
+    } catch {
+      setTimerError(`Failed to ${action} timer.`);
+      return false;
+    } finally {
+      setTimerSaving(false);
+    }
+  };
+
+  const handleKioskDialogConfirm = async (): Promise<boolean> => {
+    if (!id) return false;
+
+    setKioskTimerDialog((prev) => ({
+      ...prev,
+      loading: true,
+      error: null,
+    }));
+
+    const sessionData = await ensureKioskSession({
+      workerId: kioskTimerDialog.workerId,
+      pin: kioskTimerDialog.pin,
+    });
+    if (!sessionData) {
+      return false;
+    }
+
+    if (kioskTimerDialog.mode === 'pause' || kioskTimerDialog.mode === 'finish') {
+      closeKioskTimerDialog();
+      return runKioskTimerAction(kioskTimerDialog.mode);
+    }
+
+    const partId = kioskTimerDialog.partId.trim();
+    if (!partId) {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'Choose a part on this order.',
+      }));
+      return false;
+    }
+
+    const departmentId = kioskTimerDialog.departmentId.trim();
+    if (!departmentId) {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'This kiosk user does not have a default department configured.',
+      }));
+      return false;
+    }
+
+    try {
+      const res = await fetch('/api/kiosk/timer/start', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          orderId: id,
+          partId,
+          departmentId,
+        }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        if (res.status === 409 && data?.error?.requiredAction === 'switch_confirmation') {
+          setKioskTimerDialog((prev) => ({
+            ...prev,
+            loading: false,
+            error: null,
+            conflict: {
+              activeEntry: data.error.activeEntry ?? null,
+              activeOrder: data.error.activeOrder ?? null,
+              activePart: data.error.activePart ?? null,
+              elapsedSeconds: Number(data.error.elapsedSeconds ?? 0),
+            },
+          }));
+          return false;
+        }
+        if (res.status === 401) {
+          setKioskSession(null);
+        }
+        setKioskTimerDialog((prev) => ({
+          ...prev,
+          loading: false,
+          error:
+            typeof data?.error === 'string'
+              ? data.error
+              : typeof data?.error?.message === 'string'
+                ? data.error.message
+                : 'Failed to start timer.',
+        }));
+        return false;
+      }
+
+      setSelectedPartId(partId);
+      closeKioskTimerDialog();
+      await refreshTimerSummary();
+      await loadPartEvents();
+      await refreshKioskSession();
+      return true;
+    } catch {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'Failed to start timer.',
+      }));
+      return false;
+    }
+  };
+
+  const handleKioskSwitch = async (stopMode: 'pause' | 'finish'): Promise<boolean> => {
+    if (!id) return false;
+
+    setKioskTimerDialog((prev) => ({
+      ...prev,
+      loading: true,
+      error: null,
+    }));
+
+    const sessionData = await ensureKioskSession({
+      workerId: kioskTimerDialog.workerId,
+      pin: kioskTimerDialog.pin,
+    });
+    if (!sessionData) {
+      return false;
+    }
+
+    const partId = kioskTimerDialog.partId.trim();
+    const departmentId = kioskTimerDialog.departmentId.trim();
+    if (!partId || !departmentId) {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'Choose a part and make sure your kiosk department is configured.',
+      }));
+      return false;
+    }
+
+    try {
+      const res = await fetch('/api/kiosk/timer/switch', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({
+          orderId: id,
+          partId,
+          departmentId,
+          stopMode,
+        }),
+      });
+      const data = await res.json().catch(() => null);
+      if (!res.ok) {
+        if (res.status === 401) {
+          setKioskSession(null);
+        }
+        setKioskTimerDialog((prev) => ({
+          ...prev,
+          loading: false,
+          error:
+            typeof data?.error === 'string'
+              ? data.error
+              : typeof data?.error?.message === 'string'
+                ? data.error.message
+                : 'Failed to switch timer.',
+        }));
+        return false;
+      }
+
+      setSelectedPartId(partId);
+      closeKioskTimerDialog();
+      await refreshTimerSummary();
+      await loadPartEvents();
+      await refreshKioskSession();
+      return true;
+    } catch {
+      setKioskTimerDialog((prev) => ({
+        ...prev,
+        loading: false,
+        error: 'Failed to switch timer.',
+      }));
+      return false;
+    }
+  };
+
+  const handleKioskAction = async (action: 'pause' | 'finish'): Promise<boolean> => {
+    if (!kioskSession) {
+      openKioskTimerDialog(action);
+      return false;
+    }
+    return runKioskTimerAction(action);
   };
 
   const openMoveDepartmentDialog = () => {
@@ -1486,6 +1871,10 @@ export default function OrderDetailPage() {
   const otherTimerBadgeLabel =
     otherActiveEntryCount > 1 ? `${otherActiveEntryCount} other timers live` : 'Other timer live';
   const startHelperLabel = 'Starts a timer on the selected part for the selected department. Department moves are manual only.';
+  const kioskDefaultDepartmentName = selectedKioskWorker?.primaryDepartment?.name ?? kioskSession?.worker?.primaryDepartment?.name ?? null;
+  const kioskHelperLabel = kioskDefaultDepartmentName
+    ? `Choose a worker, choose a department, and enter that worker's PIN to time this order. ${kioskDefaultDepartmentName} is the current default department for the selected worker.`
+    : 'Choose a worker, choose a department, and enter that worker\'s PIN to time this order.';
   const selectedCurrentDepartmentIndex = selectedCurrentDepartment
     ? manualMoveDepartments.findIndex((department) => department.id === selectedCurrentDepartment.id)
     : -1;
@@ -1500,6 +1889,7 @@ export default function OrderDetailPage() {
     ? `Submit to ${selectedMoveDestination.name}`
     : 'Move part to department';
   const canMarkPartComplete = (selectedCurrentDepartment?.name ?? '').trim().toLowerCase() === 'shipping';
+  const timerReadOnlyMessage = 'Use your PIN to start, pause, stop, or switch timers for floor work on this order.';
 
   return (
     <div className="space-y-6">
@@ -1543,6 +1933,205 @@ export default function OrderDetailPage() {
             <Button type="button" onClick={() => void handleConflictAction('finish')}>
               Finish &amp; Switch
             </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+      <Dialog
+        open={kioskTimerDialog.open}
+        onOpenChange={(open) => {
+          if (!open) {
+            closeKioskTimerDialog();
+          }
+        }}
+      >
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>
+              {kioskTimerDialog.mode === 'start'
+                ? 'Start kiosk timer'
+                : kioskTimerDialog.mode === 'pause'
+                  ? 'Pause kiosk timer'
+                  : 'Stop kiosk timer'}
+            </DialogTitle>
+            <DialogDescription>
+              {kioskTimerDialog.mode === 'start'
+                ? 'Choose the worker, department, and part for this order, then enter that worker\'s PIN to start timing without leaving this page.'
+                : 'Choose the worker and department, then enter that worker\'s PIN to confirm the timer action.'}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="grid gap-2">
+              <Label htmlFor="kiosk-order-worker">Worker</Label>
+              <Select
+                value={kioskTimerDialog.workerId || '__none__'}
+                onValueChange={(value) => {
+                  const nextWorkerId = value === '__none__' ? '' : value;
+                  const nextWorker =
+                    kioskWorkers.find((user) => user.id === nextWorkerId) ?? null;
+                  setKioskTimerDialog((prev) => ({
+                    ...prev,
+                    workerId: nextWorkerId,
+                    departmentId:
+                      nextWorker?.primaryDepartmentId ??
+                      prev.departmentId ??
+                      timerDepartments[0]?.id ??
+                      '',
+                    error: null,
+                    conflict: null,
+                  }));
+                }}
+              >
+                <SelectTrigger id="kiosk-order-worker">
+                  <SelectValue placeholder="Choose worker" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">Choose worker</SelectItem>
+                  {kioskWorkers.map((worker) => (
+                    <SelectItem key={worker.id} value={worker.id}>
+                      {worker.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="kiosk-order-department">Department</Label>
+              <Select
+                value={kioskTimerDialog.departmentId || '__none__'}
+                onValueChange={(value) =>
+                  setKioskTimerDialog((prev) => ({
+                    ...prev,
+                    departmentId: value === '__none__' ? '' : value,
+                    error: null,
+                    conflict: null,
+                  }))
+                }
+              >
+                <SelectTrigger id="kiosk-order-department">
+                  <SelectValue placeholder="Choose department" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="__none__">Choose department</SelectItem>
+                  {timerDepartments.map((department) => (
+                    <SelectItem key={department.id} value={department.id}>
+                      {department.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {selectedKioskWorker?.primaryDepartment?.name ? (
+                <div className="text-xs text-muted-foreground">
+                  Default for {selectedKioskWorker.name}: {selectedKioskWorker.primaryDepartment.name}
+                </div>
+              ) : null}
+            </div>
+
+            <div className="grid gap-2">
+              <Label htmlFor="kiosk-order-pin">PIN</Label>
+              <Input
+                id="kiosk-order-pin"
+                type="password"
+                inputMode="numeric"
+                value={kioskTimerDialog.pin}
+                onChange={(event) =>
+                  setKioskTimerDialog((prev) => ({
+                    ...prev,
+                    pin: event.target.value,
+                    error: null,
+                    conflict: null,
+                  }))
+                }
+                placeholder={selectedKioskWorker ? `Enter ${selectedKioskWorker.name}'s PIN` : 'Enter worker PIN'}
+              />
+            </div>
+
+            {kioskTimerDialog.mode === 'start' ? (
+              <div className="grid gap-2">
+                <Label htmlFor="kiosk-order-part">Part on this order</Label>
+                <Select
+                  value={kioskTimerDialog.partId || '__none__'}
+                  onValueChange={(value) =>
+                    setKioskTimerDialog((prev) => ({
+                      ...prev,
+                      partId: value === '__none__' ? '' : value,
+                      error: null,
+                    }))
+                  }
+                >
+                  <SelectTrigger id="kiosk-order-part">
+                    <SelectValue placeholder="Choose part to start" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__none__">Choose part</SelectItem>
+                    {parts.map((part: any, index: number) => (
+                      <SelectItem key={part.id} value={part.id}>
+                        {part.partNumber || `Part ${index + 1}`} · Qty {part.quantity ?? 1}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            ) : null}
+
+            {kioskTimerDialog.conflict ? (
+              <div className="rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-3 text-sm text-foreground">
+                <div className="font-medium">
+                  Timer already running on{' '}
+                  {kioskTimerDialog.conflict.activeOrder?.orderNumber || 'another order'}
+                  {kioskTimerDialog.conflict.activePart?.partNumber
+                    ? ` · ${kioskTimerDialog.conflict.activePart.partNumber}`
+                    : ''}
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  Elapsed {formatDuration(kioskTimerDialog.conflict.elapsedSeconds ?? 0)}.
+                </div>
+                <div className="mt-1 text-muted-foreground">
+                  Choose whether to pause or stop that timer before switching to this order.
+                </div>
+              </div>
+            ) : null}
+
+            {kioskTimerDialog.error ? (
+              <div className="rounded-md border border-destructive/40 bg-destructive/10 px-3 py-2 text-xs text-destructive">
+                {kioskTimerDialog.error}
+              </div>
+            ) : null}
+          </div>
+          <DialogFooter className="gap-2">
+            <Button type="button" variant="outline" onClick={closeKioskTimerDialog} disabled={kioskTimerDialog.loading}>
+              Cancel
+            </Button>
+            {kioskTimerDialog.conflict ? (
+              <>
+                <Button type="button" variant="secondary" onClick={() => void handleKioskSwitch('pause')} disabled={kioskTimerDialog.loading}>
+                  {kioskTimerDialog.loading ? 'Switching…' : 'Pause & switch'}
+                </Button>
+                <Button type="button" onClick={() => void handleKioskSwitch('finish')} disabled={kioskTimerDialog.loading}>
+                  {kioskTimerDialog.loading ? 'Switching…' : 'Stop & switch'}
+                </Button>
+              </>
+            ) : (
+              <Button type="button" onClick={() => void handleKioskDialogConfirm()} disabled={kioskTimerDialog.loading}>
+                {kioskTimerDialog.loading
+                  ? kioskTimerDialog.mode === 'start'
+                    ? 'Starting…'
+                    : kioskTimerDialog.mode === 'pause'
+                      ? 'Pausing…'
+                      : 'Stopping…'
+                  : kioskSession
+                    ? kioskTimerDialog.mode === 'start'
+                      ? 'Start timer'
+                      : kioskTimerDialog.mode === 'pause'
+                        ? 'Pause timer'
+                        : 'Stop timer'
+                    : kioskTimerDialog.mode === 'start'
+                      ? 'Unlock & start'
+                      : kioskTimerDialog.mode === 'pause'
+                        ? 'Unlock & pause'
+                        : 'Unlock & stop'}
+              </Button>
+            )}
           </DialogFooter>
         </DialogContent>
       </Dialog>
@@ -2010,79 +2599,125 @@ export default function OrderDetailPage() {
                   )}
                 </div>
 
-                <div className="grid gap-2 lg:grid-cols-[220px_repeat(4,minmax(0,1fr))]">
-                  <Select value={selectedTimerDepartmentId} onValueChange={setSelectedTimerDepartmentId}>
-                    <SelectTrigger className="h-9 border-border/60 bg-background/80">
-                      <SelectValue placeholder="Choose timer department" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {timerDepartments.map((department) => (
-                        <SelectItem key={department.id} value={department.id}>
-                          {department.name}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <Button
-                    type="button"
-                    size="sm"
-                    disabled={!selectedPartId || timerSaving || activeOnSelected || !selectedTimerDepartmentId}
-                    onClick={handleActivateSelectedPart}
-                    className="justify-center gap-2"
-                  >
-                    <Play className="h-4 w-4" />
-                    Start timer
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={!selectedActiveEntry || timerSaving}
-                    onClick={() => void handlePause(selectedActiveEntry?.id)}
-                    className="justify-center gap-2"
-                  >
-                    <PauseCircle className="h-4 w-4" />
-                    Pause
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="secondary"
-                    disabled={!selectedActiveEntry || timerSaving}
-                    onClick={() => void handleFinish(selectedActiveEntry?.id)}
-                    className="justify-center gap-2"
-                  >
-                    <Square className="h-4 w-4" />
-                    Stop
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
-                    variant="outline"
-                    disabled={!selectedPartId || timerSaving || activeOnSelected || !submitDestinationOptions.length}
-                    onClick={openMoveDepartmentDialog}
-                    className="justify-center gap-2"
-                  >
-                    <CheckCircle2 className="h-4 w-4" />
-                    Submit to
-                  </Button>
-                </div>
-
-                <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/10 p-3 text-xs text-muted-foreground">
-                  <div className="flex items-start gap-2">
-                    <ArrowRightLeft className="mt-0.5 h-3.5 w-3.5" />
-                    <span>{startHelperLabel}</span>
+                {canUseTimerControls ? (
+                  <div className="grid gap-2 lg:grid-cols-[220px_repeat(4,minmax(0,1fr))]">
+                    <Select value={selectedTimerDepartmentId} onValueChange={setSelectedTimerDepartmentId}>
+                      <SelectTrigger className="h-9 border-border/60 bg-background/80">
+                        <SelectValue placeholder="Choose timer department" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {timerDepartments.map((department) => (
+                          <SelectItem key={department.id} value={department.id}>
+                            {department.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={!selectedPartId || timerSaving || activeOnSelected || !selectedTimerDepartmentId}
+                      onClick={handleActivateSelectedPart}
+                      className="justify-center gap-2"
+                    >
+                      <Play className="h-4 w-4" />
+                      Start timer
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={!selectedActiveEntry || timerSaving}
+                      onClick={() => void handlePause(selectedActiveEntry?.id)}
+                      className="justify-center gap-2"
+                    >
+                      <PauseCircle className="h-4 w-4" />
+                      Pause
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      disabled={!selectedActiveEntry || timerSaving}
+                      onClick={() => void handleFinish(selectedActiveEntry?.id)}
+                      className="justify-center gap-2"
+                    >
+                      <Square className="h-4 w-4" />
+                      Stop
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={!selectedPartId || timerSaving || activeOnSelected || !submitDestinationOptions.length}
+                      onClick={openMoveDepartmentDialog}
+                      className="justify-center gap-2"
+                    >
+                      <CheckCircle2 className="h-4 w-4" />
+                      Submit to
+                    </Button>
                   </div>
+                ) : (
+                  <div className="grid gap-2 lg:grid-cols-[repeat(3,minmax(0,1fr))]">
+                    <Button
+                      type="button"
+                      size="sm"
+                      disabled={!parts.length || timerSaving || kioskSessionLoading}
+                      onClick={() => openKioskTimerDialog('start')}
+                      className="justify-center gap-2"
+                    >
+                      <Play className="h-4 w-4" />
+                      Start timer
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      disabled={!activeEntry || timerSaving || kioskSessionLoading}
+                      onClick={() => void handleKioskAction('pause')}
+                      className="justify-center gap-2"
+                    >
+                      <PauseCircle className="h-4 w-4" />
+                      Pause
+                    </Button>
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      disabled={!activeEntry || timerSaving || kioskSessionLoading}
+                      onClick={() => void handleKioskAction('finish')}
+                      className="justify-center gap-2"
+                    >
+                      <Square className="h-4 w-4" />
+                      Stop
+                    </Button>
+                  </div>
+                )}
+
+                <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
+                  {canUseTimerControls ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="secondary"
+                      disabled={!selectedPartId || timerSaving || !canMarkPartComplete}
+                      onClick={handleCompleteSelectedPart}
+                      className="gap-2"
+                    >
+                      <CheckCircle2 className="h-4 w-4" />
+                      Complete in Shipping
+                    </Button>
+                  ) : (
+                    <span className="text-muted-foreground">{timerReadOnlyMessage}</span>
+                  )}
                   <Button
                     type="button"
                     size="sm"
-                    variant="secondary"
-                    disabled={!selectedPartId || timerSaving || !canMarkPartComplete}
-                    onClick={handleCompleteSelectedPart}
-                    className="gap-2"
+                    variant="ghost"
+                    onClick={() => setShowTimerDetails((prev) => !prev)}
+                    className="h-7 px-2 text-xs"
                   >
-                    <CheckCircle2 className="h-4 w-4" />
-                    Complete in Shipping
+                    {showTimerDetails ? 'Hide details' : 'Show details'}
                   </Button>
                 </div>
 
@@ -2091,21 +2726,27 @@ export default function OrderDetailPage() {
                     {timerError}
                   </div>
                 ) : null}
-                {selectedPartId ? (
+                {showTimerDetails && (
+                  <>
+                    <div className="flex flex-wrap items-center justify-between gap-3 rounded-md border border-border/60 bg-muted/10 p-3 text-xs text-muted-foreground">
+                      <div className="flex items-start gap-2">
+                        <ArrowRightLeft className="mt-0.5 h-3.5 w-3.5" />
+                        <span>{canUseTimerControls ? startHelperLabel : kioskHelperLabel}</span>
+                      </div>
+                      {!canUseTimerControls ? (
+                        <span className="font-medium text-foreground">
+                          {kioskSession
+                            ? `${kioskSession.worker?.name || kioskSession.worker?.email || 'Kiosk user'} unlocked`
+                            : 'PIN required for kiosk timing'}
+                        </span>
+                      ) : null}
+                    </div>
+                    {selectedPartId ? (
                   <div className="rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
                     <div><span className="font-medium text-foreground">Total time:</span> {formatDuration(selectedPartStoredSeconds)}</div>
                     <div>Timer time: {formatDuration(selectedPartTimerSeconds)}</div>
                     <div className="flex items-center justify-between gap-3">
                       <span>Manual added time: {formatDuration(selectedPartManualSeconds)}</span>
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="ghost"
-                        onClick={() => setShowTimerDetails((prev) => !prev)}
-                        className="h-7 px-2 text-xs"
-                      >
-                        {showTimerDetails ? 'Hide details' : 'Show details'}
-                      </Button>
                     </div>
                     {showTimerDetails && partManualAdjustments.length ? (
                       <div className="mt-2 space-y-1">
@@ -2154,6 +2795,8 @@ export default function OrderDetailPage() {
                     <span>Last action: none yet for this part.</span>
                   )}
                 </div>
+                  </>
+                )}
               </div>
             </div>
             <div className="flex gap-2 overflow-x-auto whitespace-nowrap rounded-md bg-muted/20 p-1">

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -9,6 +9,7 @@ import {
   LayoutDashboard,
   Menu,
   Search,
+  Timer,
   UserRound,
   Users,
   Wrench,
@@ -49,6 +50,7 @@ export default function AppNav({ companyName, initials, logoUrl }: AppNavProps) 
   const links = React.useMemo<NavLink[]>(() => {
     const items: NavLink[] = [...baseLinks];
     if (user?.role === "MACHINIST" || user?.role === "ADMIN") {
+      items.push({ href: "/kiosk", label: "Kiosk", icon: Timer });
       if (user?.id) {
         items.push({ href: `/machinists/${user.id}`, label: "Machinist Profile", icon: Wrench });
       }

--- a/src/lib/kiosk-session.ts
+++ b/src/lib/kiosk-session.ts
@@ -1,0 +1,39 @@
+import { createHmac, timingSafeEqual } from 'crypto';
+
+export const KIOSK_SESSION_COOKIE = 'shopapp_kiosk_session';
+
+function getKioskSessionSecret() {
+  return process.env.NEXTAUTH_SECRET || process.env.AUTH_SECRET || 'shopapp-kiosk-dev-secret';
+}
+
+function signValue(value: string) {
+  return createHmac('sha256', getKioskSessionSecret()).update(value).digest('hex');
+}
+
+export function createKioskSessionValue(userId: string) {
+  const payload = String(userId || '').trim();
+  const signature = signValue(payload);
+  return `${payload}.${signature}`;
+}
+
+export function readKioskSessionUserId(rawCookieValue?: string | null) {
+  if (!rawCookieValue) return null;
+  const separator = rawCookieValue.lastIndexOf('.');
+  if (separator <= 0) return null;
+  const payload = rawCookieValue.slice(0, separator);
+  const signature = rawCookieValue.slice(separator + 1);
+  const expected = signValue(payload);
+  const left = Buffer.from(signature, 'utf8');
+  const right = Buffer.from(expected, 'utf8');
+  if (left.length !== right.length) return null;
+  if (!timingSafeEqual(left, right)) return null;
+  return payload || null;
+}
+
+export const kioskSessionCookieOptions = {
+  httpOnly: true,
+  sameSite: 'lax' as const,
+  secure: process.env.NODE_ENV === 'production',
+  path: '/',
+  maxAge: 60 * 60 * 12,
+};

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -11,12 +11,16 @@ export const RoleEnum = z.enum(['ADMIN', 'MACHINIST', 'VIEWER']);
 
 /** USERS */
 const Password = z.string().min(8).max(100);
+const KioskPin = z.string().regex(/^\d{4,8}$/u, 'Kiosk PIN must be 4 to 8 digits');
 
 export const UserCreate = z.object({
   email: z.string().email(),
   name: z.string().trim().max(100).optional(),
   role: RoleEnum.default('MACHINIST'),
   active: z.boolean().default(true),
+  kioskEnabled: z.boolean().default(false),
+  primaryDepartmentId: z.string().trim().min(1).optional(),
+  kioskPin: KioskPin.optional(),
   password: Password.optional(),
 });
 export const UserUpdate = z.object({
@@ -24,6 +28,9 @@ export const UserUpdate = z.object({
   name: z.string().trim().max(100).optional(),
   role: RoleEnum.optional(),
   active: z.boolean().optional(),
+  kioskEnabled: z.boolean().optional(),
+  primaryDepartmentId: z.string().trim().min(1).optional(),
+  kioskPin: KioskPin.optional(),
   password: Password.optional(),
 });
 export const UserUpsert = UserCreate;           // for POST

--- a/src/modules/kiosk/__tests__/kiosk.service.test.ts
+++ b/src/modules/kiosk/__tests__/kiosk.service.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { hash } from 'bcryptjs';
+
+describe('kiosk.service', () => {
+  beforeEach(() => {
+    process.env.TEST_MODE = 'true';
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('unlocks a kiosk worker by PIN and returns context', async () => {
+    vi.resetModules();
+    const usersRepo = await import('@/repos/users');
+    await usersRepo.updateUser('user_test_machinist', {
+      kioskEnabled: true,
+      kioskPinHash: await hash('1234', 10),
+      primaryDepartmentId: 'dept_test_001',
+    });
+
+    const { unlockKioskByPin, getKioskSessionContext } = await import('../kiosk.service');
+    const unlockResult = await unlockKioskByPin('1234');
+    expect(unlockResult.ok).toBe(true);
+
+    const workerId = (unlockResult as { ok: true; data: { worker: { id: string } } }).data.worker.id;
+    const contextResult = await getKioskSessionContext(workerId);
+    expect(contextResult.ok).toBe(true);
+    const context = (contextResult as { ok: true; data: any }).data;
+    expect(context.worker.id).toBe('user_test_machinist');
+    expect(context.defaultDepartmentId).toBe('dept_test_001');
+    expect(Array.isArray(context.departments)).toBe(true);
+  });
+
+  it('rejects invalid kiosk PINs', async () => {
+    vi.resetModules();
+    const { unlockKioskByPin } = await import('../kiosk.service');
+    const result = await unlockKioskByPin('9999');
+    expect(result.ok).toBe(false);
+    expect((result as { ok: false; status: number }).status).toBe(401);
+  });
+
+  it('requires explicit switch when worker already has an active timer', async () => {
+    vi.resetModules();
+    const usersRepo = await import('@/repos/users');
+    await usersRepo.updateUser('user_test_machinist', {
+      kioskEnabled: true,
+      kioskPinHash: await hash('1234', 10),
+      primaryDepartmentId: 'dept_test_001',
+    });
+
+    const { startKioskTimer } = await import('../kiosk.service');
+    const firstResult = await startKioskTimer({
+      userId: 'user_test_machinist',
+      orderId: 'order_test_002',
+      partId: 'part_test_003',
+      departmentId: 'dept_test_001',
+    });
+    expect(firstResult.ok).toBe(true);
+
+    const secondResult = await startKioskTimer({
+      userId: 'user_test_machinist',
+      orderId: 'order_test_001',
+      partId: 'part_test_002',
+      departmentId: 'dept_test_002',
+    });
+    expect(secondResult.ok).toBe(false);
+    expect((secondResult as { ok: false; status: number }).status).toBe(409);
+    expect(((secondResult as { ok: false; error: any }).error).requiredAction).toBe('switch_confirmation');
+  });
+});

--- a/src/modules/kiosk/kiosk.schema.ts
+++ b/src/modules/kiosk/kiosk.schema.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const KioskUnlockInput = z.object({
+  userId: z.string().trim().min(1).optional(),
+  pin: z.string().trim().regex(/^\d{4,8}$/u, 'PIN must be 4 to 8 digits'),
+});
+
+export const KioskPartsSearchInput = z.object({
+  departmentId: z.string().trim().min(1),
+  q: z.string().trim().optional().default(''),
+  take: z.coerce.number().int().min(1).max(50).optional().default(30),
+});
+
+export const KioskTimerStartInput = z.object({
+  orderId: z.string().trim().min(1),
+  partId: z.string().trim().min(1),
+  departmentId: z.string().trim().min(1),
+});
+
+export const KioskTimerSwitchInput = KioskTimerStartInput.extend({
+  stopMode: z.enum(['pause', 'finish']),
+});

--- a/src/modules/kiosk/kiosk.service.ts
+++ b/src/modules/kiosk/kiosk.service.ts
@@ -1,0 +1,370 @@
+import 'server-only';
+
+import { compare } from 'bcryptjs';
+import { searchKioskPartsForDepartment } from '@/repos/orders';
+import { findUserByKioskId, listKioskUsers } from '@/repos/users';
+import {
+  getDepartmentsOrdered,
+  getOrderHeaderInfo,
+  getOrderPartSummary,
+  logPartEvent,
+  requirePartInstructionAcknowledgement,
+  syncOrderWorkflowStatus,
+} from '@/modules/orders/orders.service';
+import {
+  getActiveTimeEntry,
+  pauseActiveTimeEntry,
+  startTimeEntry,
+  stopActiveTimeEntry,
+} from '@/modules/time/time.service';
+
+type ServiceResult<T> = { ok: true; data: T } | { ok: false; status: number; error: string | object };
+
+function ok<T>(data: T): ServiceResult<T> {
+  return { ok: true, data };
+}
+
+function fail<T>(status: number, error: string | object): ServiceResult<T> {
+  return { ok: false, status, error };
+}
+
+function sanitizeWorker(user: any) {
+  if (!user) return null;
+  return {
+    id: user.id,
+    name: user.name ?? null,
+    email: user.email ?? null,
+    role: user.role ?? null,
+    kioskEnabled: Boolean(user.kioskEnabled),
+    active: user.active !== false,
+    primaryDepartmentId: user.primaryDepartmentId ?? null,
+    primaryDepartment: user.primaryDepartment ?? null,
+  };
+}
+
+async function resolveKioskWorker(userId: string) {
+  const user = await findUserByKioskId(userId);
+  if (!user || user.active === false) {
+    return null;
+  }
+  return user;
+}
+
+async function buildActiveTimerContext(userId: string) {
+  const activeResult = await getActiveTimeEntry(userId);
+  if (activeResult.ok === false) return activeResult;
+
+  const activeEntry = activeResult.data.entry;
+  if (!activeEntry) {
+    return ok({
+      activeEntry: null,
+      activeOrder: null,
+      activePart: null,
+      elapsedSeconds: 0,
+    });
+  }
+
+  const [orderResult, partResult] = await Promise.all([
+    getOrderHeaderInfo(activeEntry.orderId),
+    activeEntry.partId ? getOrderPartSummary(activeEntry.orderId, activeEntry.partId) : Promise.resolve(null),
+  ]);
+
+  return ok({
+    activeEntry,
+    activeOrder: orderResult.ok ? orderResult.data.order : null,
+    activePart: partResult?.ok ? partResult.data.part : null,
+    elapsedSeconds: Math.max(0, Math.floor((Date.now() - activeEntry.startedAt.getTime()) / 1000)),
+  });
+}
+
+export async function authenticateKioskWorker(pin: string, userId?: string) {
+  if (userId) {
+    const worker = await findUserByKioskId(userId);
+    if (!worker || worker.active === false) {
+      return fail(401, 'Invalid worker or PIN.');
+    }
+    if (!worker.kioskPinHash) {
+      return fail(403, 'Selected worker does not have a kiosk PIN yet.');
+    }
+    const matches = await compare(pin, worker.kioskPinHash);
+    if (!matches) {
+      return fail(401, 'Invalid worker or PIN.');
+    }
+    return ok({ worker: sanitizeWorker(worker) });
+  }
+
+  const workers = await listKioskUsers();
+  for (const worker of workers) {
+    if (!worker.kioskPinHash) continue;
+    if (await compare(pin, worker.kioskPinHash)) {
+      return ok({ worker: sanitizeWorker(worker) });
+    }
+  }
+
+  return fail(401, 'Invalid PIN.');
+}
+
+export async function getKioskWorkerSession(userId: string) {
+  const worker = await resolveKioskWorker(userId);
+  if (!worker) {
+    return fail(401, 'Kiosk session is no longer valid.');
+  }
+
+  const [departmentsResult, activeContextResult] = await Promise.all([
+    getDepartmentsOrdered(),
+    buildActiveTimerContext(userId),
+  ]);
+  if (departmentsResult.ok === false) return departmentsResult;
+  if (activeContextResult.ok === false) return activeContextResult;
+
+  return ok({
+    worker: sanitizeWorker(worker),
+    departments: departmentsResult.data.items,
+    ...activeContextResult.data,
+  });
+}
+
+export async function unlockKioskByPin(pin: string) {
+  return authenticateKioskWorker(pin);
+}
+
+export async function unlockKioskByWorkerPin({
+  userId,
+  pin,
+}: {
+  userId: string;
+  pin: string;
+}) {
+  return authenticateKioskWorker(pin, userId);
+}
+
+export async function getKioskSessionContext(userId: string) {
+  const result = await getKioskWorkerSession(userId);
+  if (result.ok === false) return result;
+
+  return ok({
+    worker: result.data.worker,
+    departments: result.data.departments,
+    defaultDepartmentId:
+      result.data.worker?.primaryDepartmentId ?? result.data.departments[0]?.id ?? null,
+    activeTimer: result.data.activeEntry
+      ? {
+          ...result.data.activeEntry,
+          order: result.data.activeOrder,
+          part: result.data.activePart,
+          elapsedSeconds: result.data.elapsedSeconds,
+        }
+      : null,
+  });
+}
+
+export async function listKioskPartsForDepartment({
+  departmentId,
+  query,
+  take,
+}: {
+  departmentId: string;
+  query?: string;
+  take?: number;
+}) {
+  const items = await searchKioskPartsForDepartment({ departmentId, query, take });
+  return ok({ items });
+}
+
+export async function startKioskWorkerTimer({
+  userId,
+  orderId,
+  partId,
+  departmentId,
+  switchAction,
+}: {
+  userId: string;
+  orderId: string;
+  partId: string;
+  departmentId: string;
+  switchAction?: 'pause' | 'finish';
+}) {
+  const worker = await resolveKioskWorker(userId);
+  if (!worker) {
+    return fail(401, 'Kiosk session is no longer valid.');
+  }
+
+  const departmentsResult = await getDepartmentsOrdered();
+  if (departmentsResult.ok === false) return departmentsResult;
+  const selectedDepartment = departmentsResult.data.items.find((department) => department.id === departmentId);
+  if (!selectedDepartment) return fail(400, 'Department not found.');
+  if (selectedDepartment.name.trim().toLowerCase() === 'shipping') {
+    return fail(400, 'Shipping timers are disabled.');
+  }
+
+  const partResult = await getOrderPartSummary(orderId, partId);
+  if (partResult.ok === false) return partResult;
+
+  const ackResult = await requirePartInstructionAcknowledgement({
+    orderId,
+    partId,
+    userId,
+    departmentId,
+  });
+  if (ackResult.ok === false) return ackResult;
+
+  const activeContextResult = await buildActiveTimerContext(userId);
+  if (activeContextResult.ok === false) return activeContextResult;
+  const activeEntry = activeContextResult.data.activeEntry;
+
+  if (activeEntry) {
+    if (!switchAction) {
+      return fail(409, {
+        message: 'Active time entry already running.',
+        requiredAction: 'switch_confirmation',
+        activeEntry: activeContextResult.data.activeEntry,
+        activeOrder: activeContextResult.data.activeOrder,
+        activePart: activeContextResult.data.activePart,
+        elapsedSeconds: activeContextResult.data.elapsedSeconds,
+      });
+    }
+
+    const closeResult =
+      switchAction === 'pause' ? await pauseActiveTimeEntry(userId) : await stopActiveTimeEntry(userId);
+    if (closeResult.ok === false) return closeResult;
+
+    const closedEntry = closeResult.data.entry;
+    if (closedEntry.partId) {
+      await logPartEvent({
+        orderId: closedEntry.orderId,
+        partId: closedEntry.partId,
+        userId,
+        type: switchAction === 'pause' ? 'TIMER_PAUSED' : 'TIMER_FINISHED',
+        message: switchAction === 'pause' ? 'Timer paused from kiosk switch.' : 'Timer finished from kiosk switch.',
+        meta: { timeEntryId: closedEntry.id, transitionSource: 'kiosk_switch' },
+      });
+      await syncOrderWorkflowStatus(closedEntry.orderId, { userId });
+    }
+  }
+
+  const startResult = await startTimeEntry(userId, {
+    orderId,
+    partId,
+    departmentId,
+    operation: 'Part Work',
+  });
+  if (startResult.ok === false) return startResult;
+
+  await logPartEvent({
+    orderId,
+    partId,
+    userId,
+    type: 'TIMER_STARTED',
+    message: 'Timer started from kiosk.',
+    meta: { timeEntryId: startResult.data.entry.id, transitionSource: 'kiosk' },
+  });
+  await syncOrderWorkflowStatus(orderId, { userId });
+
+  return ok({ entry: startResult.data.entry });
+}
+
+export async function startKioskTimer({
+  userId,
+  orderId,
+  partId,
+  departmentId,
+}: {
+  userId: string;
+  orderId: string;
+  partId: string;
+  departmentId: string;
+}) {
+  return startKioskWorkerTimer({ userId, orderId, partId, departmentId });
+}
+
+export async function pauseKioskWorkerTimer(userId: string) {
+  if (!(await resolveKioskWorker(userId))) {
+    return fail(401, 'Kiosk session is no longer valid.');
+  }
+
+  const result = await pauseActiveTimeEntry(userId);
+  if (result.ok === false) return result;
+
+  if (result.data.entry.partId) {
+    await logPartEvent({
+      orderId: result.data.entry.orderId,
+      partId: result.data.entry.partId,
+      userId,
+      type: 'TIMER_PAUSED',
+      message: 'Timer paused from kiosk.',
+      meta: { timeEntryId: result.data.entry.id, transitionSource: 'kiosk' },
+    });
+  }
+
+  return ok({ entry: result.data.entry });
+}
+
+export async function finishKioskWorkerTimer(userId: string) {
+  if (!(await resolveKioskWorker(userId))) {
+    return fail(401, 'Kiosk session is no longer valid.');
+  }
+
+  const result = await stopActiveTimeEntry(userId);
+  if (result.ok === false) return result;
+
+  if (result.data.entry.partId) {
+    await logPartEvent({
+      orderId: result.data.entry.orderId,
+      partId: result.data.entry.partId,
+      userId,
+      type: 'TIMER_FINISHED',
+      message: 'Timer finished from kiosk.',
+      meta: { timeEntryId: result.data.entry.id, transitionSource: 'kiosk' },
+    });
+    await syncOrderWorkflowStatus(result.data.entry.orderId, { userId });
+  }
+
+  return ok({ entry: result.data.entry });
+}
+
+export async function searchKioskParts({
+  userId,
+  departmentId,
+  query,
+  take,
+}: {
+  userId: string;
+  departmentId: string;
+  query?: string;
+  take?: number;
+}) {
+  if (!(await resolveKioskWorker(userId))) {
+    return fail(401, 'Kiosk session is no longer valid.');
+  }
+  return listKioskPartsForDepartment({ departmentId, query, take });
+}
+
+export async function pauseKioskTimer(userId: string) {
+  return pauseKioskWorkerTimer(userId);
+}
+
+export async function finishKioskTimer(userId: string) {
+  return finishKioskWorkerTimer(userId);
+}
+
+export async function switchKioskTimer({
+  userId,
+  orderId,
+  partId,
+  departmentId,
+  stopMode,
+}: {
+  userId: string;
+  orderId: string;
+  partId: string;
+  departmentId: string;
+  stopMode: 'pause' | 'finish';
+}) {
+  return startKioskWorkerTimer({
+    userId,
+    orderId,
+    partId,
+    departmentId,
+    switchAction: stopMode,
+  });
+}

--- a/src/modules/orders/orders.repo.ts
+++ b/src/modules/orders/orders.repo.ts
@@ -1303,3 +1303,50 @@ export async function searchOrdersByTerm(query: string, variants: string[]) {
     take: 60,
   });
 }
+
+export async function searchKioskPartsForDepartment({
+  departmentId,
+  query,
+  take = 30,
+}: {
+  departmentId: string;
+  query?: string;
+  take?: number;
+}) {
+  const normalized = query?.trim();
+
+  return prisma.orderPart.findMany({
+    where: {
+      currentDepartmentId: departmentId,
+      status: { not: 'COMPLETE' },
+      ...(normalized
+        ? {
+            OR: [
+              { partNumber: { contains: normalized, mode: 'insensitive' } },
+              { order: { orderNumber: { contains: normalized, mode: 'insensitive' } } },
+              { order: { customer: { name: { contains: normalized, mode: 'insensitive' } } } },
+            ],
+          }
+        : {}),
+    },
+    orderBy: [{ order: { dueDate: 'asc' } }, { order: { orderNumber: 'asc' } }, { partNumber: 'asc' }],
+    take,
+    select: {
+      id: true,
+      partNumber: true,
+      quantity: true,
+      currentDepartmentId: true,
+      currentDepartment: { select: { id: true, name: true } },
+      orderId: true,
+      order: {
+        select: {
+          id: true,
+          orderNumber: true,
+          dueDate: true,
+          priority: true,
+          customer: { select: { id: true, name: true } },
+        },
+      },
+    },
+  });
+}

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -745,7 +745,10 @@ export async function ensureOrderFilesInCanonicalStorage(orderId: string) {
   return ok({ ok: true });
 }
 
-export async function getOrderDetails(id: string, isAdmin: boolean) {
+export async function getOrderDetails(
+  id: string,
+  options: { isAdmin: boolean; canUseTimerControls?: boolean },
+) {
   const order = await findOrderWithDetails(id);
   if (!order) return fail(404, 'Not found');
   const departments = await listDepartmentsOrdered();
@@ -754,7 +757,7 @@ export async function getOrderDetails(id: string, isAdmin: boolean) {
     ? buildPartActivityByPart(partIds, await listTimeEntriesForPartsDetailed(partIds))
     : {};
 
-  const sanitized = sanitizePricingForNonAdmin(order, isAdmin) as any;
+  const sanitized = sanitizePricingForNonAdmin(order, options.isAdmin) as any;
   sanitized.status = normalizeOrderWorkflowStatus(sanitized.status);
   sanitized.parts = Array.isArray(sanitized.parts)
     ? sanitized.parts.map((part: any) => {
@@ -783,7 +786,11 @@ export async function getOrderDetails(id: string, isAdmin: boolean) {
   return ok({
     item: sanitized,
     departments,
-    permissions: { canEditParts: isAdmin, canEditOrderStatus: isAdmin },
+    permissions: {
+      canEditParts: options.isAdmin,
+      canEditOrderStatus: options.isAdmin,
+      canUseTimerControls: options.canUseTimerControls !== false,
+    },
   });
 }
 

--- a/src/modules/time/__tests__/time.service.test.ts
+++ b/src/modules/time/__tests__/time.service.test.ts
@@ -92,16 +92,17 @@ describe('time.service', () => {
       departmentId: 'dept_test_002',
       operation: 'Part Work',
     });
-    expect(parallelResult.ok).toBe(true);
+    expect(parallelResult.ok).toBe(false);
+    expect((parallelResult as { ok: false; status: number }).status).toBe(409);
 
     const activeResult = await getActiveTimeEntry('user_test_machinist');
     expect(activeResult.ok).toBe(true);
     const activeEntry = (activeResult as { ok: true; data: { entry: any } }).data.entry;
-    expect(['part_test_001', 'part_test_002']).toContain(activeEntry?.partId);
+    expect(activeEntry?.partId).toBe('part_test_001');
     expect(activeEntry?.endedAt).toBeNull();
   });
 
-  it('tracks separate department timers without overlap inflation', async () => {
+  it('prevents overlapping timers across departments for the same user', async () => {
     vi.setSystemTime(new Date('2026-02-03T00:00:00Z'));
     vi.resetModules();
     const { getOrderPartTimeTotals, startTimeEntry, startTimeEntryWithConflict, stopTimeEntryById } = await import('../time.service');
@@ -126,20 +127,17 @@ describe('time.service', () => {
       departmentId: 'dept_test_002',
       operation: 'Part Work',
     });
-    expect(secondDepartmentStart.ok).toBe(true);
-    const secondEntryId = (secondDepartmentStart as { ok: true; data: { entry: any } }).data.entry.id;
+    expect(secondDepartmentStart.ok).toBe(false);
 
     vi.setSystemTime(new Date('2026-02-03T00:25:00Z'));
     const stoppedFirst = await stopTimeEntryById('user_test_machinist', firstEntryId);
-    const stoppedSecond = await stopTimeEntryById('user_test_machinist', secondEntryId);
     expect(stoppedFirst.ok).toBe(true);
-    expect(stoppedSecond.ok).toBe(true);
 
     const totalsResult = await getOrderPartTimeTotals(switchOrderId, [firstPartId, secondPartId]);
     expect(totalsResult.ok).toBe(true);
     const totals = (totalsResult as { ok: true; data: { totalsSeconds: Record<string, number> } }).data.totalsSeconds;
     expect(totals[firstPartId]).toBe(1500);
-    expect(totals[secondPartId]).toBe(900);
+    expect(totals[secondPartId] ?? 0).toBe(0);
   });
 
 
@@ -236,5 +234,36 @@ describe('time.service', () => {
     expect(activity.activeTimers.some((entry) => entry.userId === 'user_test_machinist')).toBe(true);
     expect(activity.timeByUser.some((entry) => entry.user?.id === 'user_test_helper' && entry.seconds > 0)).toBe(true);
     expect(activity.totalSeconds).toBeGreaterThan(0);
+  });
+
+  it('builds reporting summaries by part, department, and user', async () => {
+    vi.setSystemTime(new Date('2026-02-03T00:00:00Z'));
+    vi.resetModules();
+    const { getPartTimeReportingSummary, startTimeEntry } = await import('../time.service');
+
+    const startResult = await startTimeEntry('user_test_machinist', {
+      orderId: 'order_test_002',
+      partId: 'part_test_003',
+      departmentId: 'dept_test_001',
+      operation: 'Part Work',
+    });
+    expect(startResult.ok).toBe(true);
+
+    const summaryResult = await getPartTimeReportingSummary(['part_test_001', 'part_test_003']);
+    expect(summaryResult.ok).toBe(true);
+    const summary = (summaryResult as {
+      ok: true;
+      data: {
+        totalsByPartDepartment: Record<string, Record<string, number>>;
+        totalsByPartUser: Record<string, Record<string, number>>;
+        totalsByDepartmentUser: Record<string, Record<string, number>>;
+        activeByUser: Record<string, { partId: string | null }>;
+      };
+    }).data;
+
+    expect(summary.totalsByPartDepartment['part_test_001']?.dept_test_001).toBeGreaterThan(0);
+    expect(summary.totalsByPartUser['part_test_001']?.user_test_helper).toBeGreaterThan(0);
+    expect(summary.totalsByDepartmentUser['dept_test_001']?.user_test_helper).toBeGreaterThan(0);
+    expect(summary.activeByUser['user_test_machinist']?.partId).toBe('part_test_003');
   });
 });

--- a/src/modules/time/time.service.ts
+++ b/src/modules/time/time.service.ts
@@ -3,7 +3,6 @@ import {
   closeTimeEntryById,
   createTimeEntry,
   findActiveTimeEntryForUser,
-  findActiveTimeEntryForUserDepartment,
   findLatestTimeEntriesForUserParts,
   findLatestTimeEntryForUserOrder,
   findTimeEntryById,
@@ -101,9 +100,9 @@ export async function startTimeEntry(
   input: TimeEntryStartInput
 ): Promise<ServiceResult<{ entry: TimeEntry }>> {
   const now = new Date();
-  const activeInDepartment = await findActiveTimeEntryForUserDepartment(userId, input.departmentId);
-  if (activeInDepartment) {
-    return fail(409, 'An active timer already exists for this department.');
+  const active = await findActiveTimeEntryForUser(userId);
+  if (active) {
+    return fail(409, 'An active timer already exists for this user.');
   }
 
   try {
@@ -126,7 +125,7 @@ export async function startTimeEntryWithConflict(
   userId: string,
   input: TimeEntryStartInput
 ): Promise<ServiceResult<{ entry: TimeEntry }>> {
-  const active = await findActiveTimeEntryForUserDepartment(userId, input.departmentId);
+  const active = await findActiveTimeEntryForUser(userId);
   if (active) {
     return fail(409, 'Active time entry already running.');
   }
@@ -229,9 +228,9 @@ export async function resumeTimeEntry(
   }
 
   const now = new Date();
-  const activeInDepartment = await findActiveTimeEntryForUserDepartment(userId, previous.departmentId);
-  if (activeInDepartment) {
-    return fail(409, 'An active timer already exists for this department.');
+  const active = await findActiveTimeEntryForUser(userId);
+  if (active) {
+    return fail(409, 'An active timer already exists for this user.');
   }
 
   try {
@@ -366,6 +365,64 @@ export async function getPartActivitySummary(
   });
 
   return ok({ partActivity });
+}
+
+export async function getPartTimeReportingSummary(
+  partIds: string[],
+): Promise<
+  ServiceResult<{
+    totalsByPartDepartment: Record<string, Record<string, number>>;
+    totalsByPartUser: Record<string, Record<string, number>>;
+    totalsByDepartmentUser: Record<string, Record<string, number>>;
+    activeByUser: Record<string, TimeEntry>;
+  }>
+> {
+  if (!partIds.length) {
+    return ok({
+      totalsByPartDepartment: {},
+      totalsByPartUser: {},
+      totalsByDepartmentUser: {},
+      activeByUser: {},
+    });
+  }
+
+  const entries = await listTimeEntriesForPartsDetailed(partIds);
+  const totalsByPartDepartment: Record<string, Record<string, number>> = {};
+  const totalsByPartUser: Record<string, Record<string, number>> = {};
+  const totalsByDepartmentUser: Record<string, Record<string, number>> = {};
+  const activeByUser: Record<string, TimeEntry> = {};
+
+  entries.forEach((entry) => {
+    if (!entry.partId) return;
+
+    if (!entry.endedAt) {
+      if (!activeByUser[entry.userId]) {
+        activeByUser[entry.userId] = entry;
+      }
+      return;
+    }
+
+    const diffMs = entry.endedAt.getTime() - entry.startedAt.getTime();
+    if (diffMs <= 0) return;
+
+    const seconds = Math.floor(diffMs / 1000);
+    const partDepartmentKey = entry.departmentId ?? '__none__';
+    const departmentUserKey = entry.departmentId ?? '__none__';
+
+    totalsByPartDepartment[entry.partId] ??= {};
+    totalsByPartDepartment[entry.partId][partDepartmentKey] =
+      (totalsByPartDepartment[entry.partId][partDepartmentKey] ?? 0) + seconds;
+
+    totalsByPartUser[entry.partId] ??= {};
+    totalsByPartUser[entry.partId][entry.userId] =
+      (totalsByPartUser[entry.partId][entry.userId] ?? 0) + seconds;
+
+    totalsByDepartmentUser[departmentUserKey] ??= {};
+    totalsByDepartmentUser[departmentUserKey][entry.userId] =
+      (totalsByDepartmentUser[departmentUserKey][entry.userId] ?? 0) + seconds;
+  });
+
+  return ok({ totalsByPartDepartment, totalsByPartUser, totalsByDepartmentUser, activeByUser });
 }
 
 export function computeEntryMinutes(entries: Array<Pick<TimeEntry, 'startedAt' | 'endedAt'>>) {

--- a/src/modules/users/users.repo.ts
+++ b/src/modules/users/users.repo.ts
@@ -1,5 +1,22 @@
 import { prisma } from '@/lib/prisma';
 
+const userInclude = {
+  primaryDepartment: {
+    select: {
+      id: true,
+      name: true,
+    },
+  },
+} as const;
+
+function sanitizeUser<T extends Record<string, unknown>>(item: T) {
+  const { passwordHash, kioskPinHash, ...rest } = item as T & {
+    passwordHash?: unknown;
+    kioskPinHash?: unknown;
+  };
+  return rest;
+}
+
 export async function listUsers({
   q,
   role,
@@ -26,28 +43,55 @@ export async function listUsers({
     where: Object.keys(where).length ? where : undefined,
     orderBy: { id: 'asc' },
     take: take + 1,
+    include: userInclude,
     ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
   });
 
   const nextCursor = items.length > take ? (items[take] as any).id : null;
   if (nextCursor) items.pop();
 
-  const sanitized = items.map(({ passwordHash, ...rest }) => rest);
+  const sanitized = items.map((item) => sanitizeUser(item as Record<string, unknown>));
   return { items: sanitized, nextCursor };
 }
 
 export async function createUser(data: Record<string, unknown>) {
-  const item = await prisma.user.create({ data });
-  const { passwordHash, ...rest } = item as any;
-  return rest;
+  const item = await prisma.user.create({ data, include: userInclude });
+  return sanitizeUser(item as Record<string, unknown>);
 }
 
 export async function updateUser(id: string, data: Record<string, unknown>) {
-  const item = await prisma.user.update({ where: { id }, data });
-  const { passwordHash, ...rest } = item as any;
-  return rest;
+  const item = await prisma.user.update({ where: { id }, data, include: userInclude });
+  return sanitizeUser(item as Record<string, unknown>);
 }
 
 export async function findUserById(id: string) {
-  return prisma.user.findUnique({ where: { id } });
+  return prisma.user.findUnique({ where: { id }, include: userInclude });
+}
+
+export async function findUserByKioskId(id: string) {
+  return prisma.user.findUnique({
+    where: { id },
+    include: userInclude,
+  });
+}
+
+export async function findKioskUserByPinEligibility(emailOrId: { id?: string; email?: string }) {
+  return prisma.user.findFirst({
+    where: {
+      active: true,
+      ...(emailOrId.id ? { id: emailOrId.id } : {}),
+      ...(emailOrId.email ? { email: emailOrId.email } : {}),
+    },
+    include: userInclude,
+  });
+}
+
+export async function listKioskUsers() {
+  return prisma.user.findMany({
+    where: {
+      active: true,
+    },
+    orderBy: [{ name: 'asc' }, { email: 'asc' }],
+    include: userInclude,
+  });
 }

--- a/src/repos/mock/orders.ts
+++ b/src/repos/mock/orders.ts
@@ -1006,6 +1006,53 @@ export function createMockOrdersRepo() {
         });
     },
 
+    async searchKioskPartsForDepartment({
+      departmentId,
+      query,
+      take = 30,
+    }: {
+      departmentId: string;
+      query?: string;
+      take?: number;
+    }) {
+      const normalized = query?.trim().toLowerCase() ?? '';
+      return state.orderParts
+        .filter((part) => {
+          if (part.currentDepartmentId !== departmentId) return false;
+          if (part.status === 'COMPLETE') return false;
+          if (!normalized) return true;
+          const order = state.orders.find((item) => item.id === part.orderId);
+          const customer = order ? state.customers.find((item) => item.id === order.customerId) : null;
+          return (
+            (part.partNumber ?? '').toLowerCase().includes(normalized) ||
+            (order?.orderNumber ?? '').toLowerCase().includes(normalized) ||
+            (customer?.name ?? '').toLowerCase().includes(normalized)
+          );
+        })
+        .slice(0, take)
+        .map((part) => {
+          const order = state.orders.find((item) => item.id === part.orderId);
+          const customer = order ? state.customers.find((item) => item.id === order.customerId) : null;
+          return {
+            id: part.id,
+            partNumber: part.partNumber,
+            quantity: part.quantity,
+            currentDepartmentId: part.currentDepartmentId,
+            currentDepartment: state.departments.find((department) => department.id === part.currentDepartmentId) ?? null,
+            orderId: part.orderId,
+            order: order
+              ? {
+                  id: order.id,
+                  orderNumber: order.orderNumber,
+                  dueDate: order.dueDate,
+                  priority: order.priority,
+                  customer: customer ? { id: customer.id, name: customer.name } : null,
+                }
+              : null,
+          };
+        });
+    },
+
 
     async getDashboardOrderOverview() {
       const totalOrders = state.orders.length;

--- a/src/repos/mock/seed.ts
+++ b/src/repos/mock/seed.ts
@@ -5,6 +5,10 @@ export type MockUser = {
   role: string;
   admin: boolean;
   active: boolean;
+  kioskEnabled?: boolean;
+  kioskPinHash?: string | null;
+  primaryDepartmentId?: string | null;
+  primaryDepartment?: { id: string; name: string } | null;
 };
 
 export type MockCustomer = {
@@ -226,6 +230,10 @@ export function createMockSeedState(): MockSeedState {
       role: 'ADMIN',
       admin: true,
       active: true,
+      kioskEnabled: false,
+      kioskPinHash: null,
+      primaryDepartmentId: null,
+      primaryDepartment: null,
     },
     {
       id: 'user_test_machinist',
@@ -234,6 +242,10 @@ export function createMockSeedState(): MockSeedState {
       role: 'MACHINIST',
       admin: false,
       active: true,
+      kioskEnabled: true,
+      kioskPinHash: '$2a$10$zi2x9sQLiP8W.idNF7RWMO7Y6YyQzTAXJCTDIVMUuc2ayfmwgyY0y',
+      primaryDepartmentId: 'dept_test_001',
+      primaryDepartment: { id: 'dept_test_001', name: 'Machining' },
     },
     {
       id: 'user_test_helper',
@@ -242,6 +254,10 @@ export function createMockSeedState(): MockSeedState {
       role: 'MACHINIST',
       admin: false,
       active: true,
+      kioskEnabled: true,
+      kioskPinHash: '$2a$10$jqCXFAh0oeY59faoQzQPiOUYNTzudIvIYa7jqWL85BoeK9d6oaKtO',
+      primaryDepartmentId: 'dept_test_002',
+      primaryDepartment: { id: 'dept_test_002', name: 'Finishing' },
     },
   ];
 

--- a/src/repos/mock/users.ts
+++ b/src/repos/mock/users.ts
@@ -3,6 +3,11 @@ import { createMockSeedState } from './seed';
 export function createMockUsersRepo() {
   const state = createMockSeedState();
 
+  function sanitizeUser<T extends Record<string, unknown>>(item: T) {
+    const { kioskPinHash, ...rest } = item as T & { kioskPinHash?: unknown };
+    return rest;
+  }
+
   return {
     async listUsers({ q, role, take, cursor }: { q?: string; role?: string; take: number; cursor?: string | null }) {
       let items = [...state.users];
@@ -22,7 +27,7 @@ export function createMockUsersRepo() {
       const sliced = items.slice(0, take + 1);
       const nextCursor = sliced.length > take ? sliced[take].id : null;
       if (nextCursor) sliced.pop();
-      return { items: sliced, nextCursor };
+      return { items: sliced.map((item) => sanitizeUser(item)), nextCursor };
     },
 
     async createUser(data: Record<string, unknown>) {
@@ -33,20 +38,48 @@ export function createMockUsersRepo() {
         role: (data.role as string) ?? 'MACHINIST',
         admin: Boolean(data.admin ?? false),
         active: data.active !== false,
+        kioskEnabled: Boolean(data.kioskEnabled ?? false),
+        kioskPinHash: (data.kioskPinHash as string) ?? null,
+        primaryDepartmentId: (data.primaryDepartmentId as string) ?? null,
+        primaryDepartment:
+          state.departments.find((department) => department.id === data.primaryDepartmentId) ?? null,
       };
       state.users.push(user);
-      return user;
+      return sanitizeUser(user);
     },
 
     async updateUser(id: string, data: Record<string, unknown>) {
       const user = state.users.find((item) => item.id === id);
       if (!user) throw new Error('User not found');
       Object.assign(user, data);
-      return user;
+      user.primaryDepartment =
+        state.departments.find((department) => department.id === user.primaryDepartmentId) ?? null;
+      return sanitizeUser(user);
     },
 
     async findUserById(id: string) {
       return state.users.find((user) => user.id === id) ?? null;
+    },
+
+    async findUserByKioskId(id: string) {
+      return state.users.find((user) => user.id === id) ?? null;
+    },
+
+    async findKioskUserByPinEligibility(emailOrId: { id?: string; email?: string }) {
+      return (
+        state.users.find(
+          (user) =>
+            user.active !== false &&
+            (emailOrId.id ? user.id === emailOrId.id : true) &&
+            (emailOrId.email ? user.email === emailOrId.email : true),
+        ) ?? null
+      );
+    },
+
+    async listKioskUsers() {
+      return state.users
+        .filter((user) => user.active !== false)
+        .map((user) => ({ ...user }));
     },
   };
 }

--- a/src/repos/orders.ts
+++ b/src/repos/orders.ts
@@ -82,3 +82,4 @@ export const listAddonsByIds = repo.listAddonsByIds;
 export const listReadyOrderPartsForDepartment = repo.listReadyOrderPartsForDepartment;
 export const getDashboardOrderOverview = repo.getDashboardOrderOverview;
 export const searchOrdersByTerm = repo.searchOrdersByTerm;
+export const searchKioskPartsForDepartment = repo.searchKioskPartsForDepartment;

--- a/src/repos/users.ts
+++ b/src/repos/users.ts
@@ -6,3 +6,6 @@ export const listUsers = repo.listUsers;
 export const createUser = repo.createUser;
 export const updateUser = repo.updateUser;
 export const findUserById = repo.findUserById;
+export const findUserByKioskId = repo.findUserByKioskId;
+export const findKioskUserByPinEligibility = repo.findKioskUserByPinEligibility;
+export const listKioskUsers = repo.listKioskUsers;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,82 @@
 ## Session Metadata
 - Date: 2026-04-10
 - Agent: Codex GPT-5
+- Task ID: Order-detail embedded kiosk timing follow-up
+- Goal: Replace the separate kiosk-page launch from `/orders/[id]` with an in-page PIN-and-part kiosk timer dialog while keeping kiosk/user/department timing rules intact.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current kiosk behavior in code:
+  - kiosk-enabled machinists already lose normal timer controls on `/orders/[id]`,
+  - the fallback currently sends them to `/kiosk`,
+  - kiosk unlock/session/timer APIs already exist and should be reused instead of duplicating timer business logic.
+
+## Plan First
+- [x] Replace the order-detail kiosk fallback CTA with inline kiosk timer controls and a modal dialog.
+- [x] Reuse kiosk unlock/session/start/pause/finish/switch APIs from the order page so PIN, worker ownership, and department rules stay server-enforced.
+- [x] Run focused verification and update continuity docs with the revised UX behavior.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+## Review + Results
+- Replaced the `/orders/[id]` kiosk fallback link with in-page kiosk controls in the existing timer area.
+- Kiosk-enabled machinists now open a modal on the order page to:
+  - choose a worker,
+  - choose a department,
+  - enter that worker's PIN,
+  - choose a part from the current order,
+  - start work without leaving the order-detail screen.
+- Pause/stop actions for kiosk-enabled machinists now also work from the order page and reuse the same kiosk unlock/session flow when needed.
+- Existing kiosk API/session/timer enforcement stays intact, including:
+  - user-specific timer ownership,
+  - explicit department choice with worker-default suggestion,
+  - active-timer switch confirmation when another timer is already running.
+- Moved the helper/status/time-breakdown content under `Show details` so the timer header stays cleaner by default.
+
+## Session Metadata
+- Date: 2026-04-10
+- Agent: Codex GPT-5
+- Task ID: Shared kiosk timing + read-only order detail for floor users
+- Goal: Add a PIN-based shared kiosk timing flow with one-active-timer-per-worker enforcement, keep order detail available for review, and hide timer actions there for kiosk-designated floor users.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated current code shape:
+  - `TimeEntry` already stores `userId`, `partId`, and `departmentId`,
+  - timer services currently allow one active timer per user per department, not one total,
+  - `/orders/[id]` still owns the current timer controls,
+  - there is no kiosk session/auth flow yet,
+  - admin Users UI/API exists and is the right setup surface for kiosk fields.
+
+## Plan First
+- [x] Extend `User` and admin user management for kiosk PIN/default department/kiosk eligibility.
+- [x] Add kiosk session helpers and kiosk auth/session/timer/search API routes.
+- [x] Change timer backend enforcement to one active timer total per worker and include conflict context for switch UX.
+- [x] Add `/kiosk` timing UI and hide order-detail timer actions for kiosk-enabled floor users while preserving read-only review access.
+- [x] Add/update focused tests and run relevant verification.
+- [x] Update continuity docs with evidence and behavior notes.
+
+## Verification Checklist
+- [x] `npx prisma migrate dev --name kiosk_user_timing_v1`
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/kiosk/page.tsx" "src/app/api/kiosk/unlock/route.ts" "src/app/api/kiosk/session/route.ts" "src/app/api/kiosk/lock/route.ts" "src/app/api/kiosk/parts/route.ts" "src/app/api/kiosk/timer/route.ts" "src/app/api/orders/[id]/route.ts" "src/app/api/timer/start/route.ts" "src/app/orders/[id]/page.tsx" "src/components/AppNav.tsx" "src/modules/kiosk/kiosk.service.ts" "src/modules/kiosk/kiosk.schema.ts" "src/modules/time/time.service.ts" "src/modules/users/users.repo.ts" "src/repos/users.ts" "src/repos/mock/users.ts" "src/repos/mock/seed.ts" "src/modules/time/__tests__/time.service.test.ts" "src/modules/kiosk/__tests__/kiosk.service.test.ts"`
+- [x] `npm run test -- src/modules/time/__tests__/time.service.test.ts src/modules/kiosk/__tests__/kiosk.service.test.ts`
+
+## Review + Results
+- Added kiosk-ready user fields (`kioskEnabled`, `kioskPinHash`, `primaryDepartmentId`) plus admin management support for PIN/default department setup.
+- Added a dedicated `/kiosk` flow with PIN unlock, signed kiosk session cookie, department-scoped part search, active-timer context, and explicit start/pause/stop/switch actions.
+- Changed timer enforcement to one active timer total per worker, regardless of department, while preserving `departmentId` on each `TimeEntry` and adding reporting summaries for part/department/user rollups.
+- Kept `/orders/[id]` available for notes/files/checklists/logs, but hid timer controls there for kiosk-enabled machinists and replaced them with a kiosk-only timing message/link.
+- Added focused kiosk/time tests and captured the Prisma client file-lock caveat during migration.
+
+## Notes
+- `npx prisma migrate dev --name kiosk_user_timing_v1` applied successfully and created `prisma/migrations/20260410174437_kiosk_user_timing_v1/migration.sql`.
+- Prisma generate inside the migration hit a Windows file-lock `EPERM` while renaming `query_engine-windows.dll.node`; the migration itself completed and focused lint/tests passed afterward.
+- Focused Vitest execution still required an outside-sandbox rerun because sandboxed esbuild hit Windows `spawn EPERM`.
+
+## Session Metadata
+- Date: 2026-04-10
+- Agent: Codex GPT-5
 - Task ID: Order-detail layout shift for part-heavy orders
 - Goal: Give the full left rail to the parts list, move timer/submit controls into the top of the right-side detail area, and remove the admin order-status block from this screen.
 


### PR DESCRIPTION
## Summary
- restore the kiosk timing implementation and related schema/service/api pieces that were present locally but missing from the branch
- embed the primary kiosk timing flow into the order detail page instead of forcing a separate kiosk page for normal use
- require worker selection, department selection, and PIN entry in the order-detail dialog while showing timer details under a "Show details" affordance

## Verification
- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/modules/kiosk/kiosk.service.ts" "src/modules/users/users.repo.ts" "src/repos/mock/users.ts"`
- `npm run test -- src/modules/time/__tests__/time.service.test.ts src/modules/kiosk/__tests__/kiosk.service.test.ts`

## Notes
- left `prisma/prisma/dev.db` out of the PR because it is a local environment artifact
- stash `stash@{0}` was intentionally left in place for safety earlier in the session