### PR TITLE
[codex] Polish order detail timing and queue workflow

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,3 +1,86 @@
+### 2026-04-13 - Department queue now prioritizes active timers, shows timer chips, preserves completed department ownership, and Vendors has pagination
+- Updated `src/modules/orders/orders.service.ts` and `src/components/work-queue/WorkQueueOrderCard.tsx` so department work-queue cards now:
+  - sort orders with active timers to the top before the existing flagged/due-date ordering,
+  - display small green active-timer chips on each order tile showing worker + elapsed time.
+- Updated completion routing in `src/modules/orders/orders.service.ts` so completed/shipped parts keep their final department ownership instead of falling back to an unassigned/null department:
+  - manual `Mark Shipped` completion now preserves `Shipping`,
+  - department-submit completion now preserves the last department when the part reaches `COMPLETE`.
+- Updated `src/components/ShopFloorLayouts.tsx` so the existing checkbox label now reads `Show completed items`, matching the completed-item visibility behavior for department feeds.
+- Updated the Vendors admin list in:
+  - `src/app/admin/vendors/page.tsx`,
+  - `src/app/admin/vendors/client.tsx`,
+  - `src/app/api/admin/vendors/route.ts`
+  so it now uses page-based pagination with `Previous` / `Next` controls and total-count awareness instead of a one-way `Load more` flow.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/components/ShopFloorLayouts.tsx" "src/components/work-queue/WorkQueueOrderCard.tsx" "src/modules/orders/orders.service.ts" "src/modules/orders/orders.types.ts" "src/app/admin/vendors/client.tsx" "src/app/admin/vendors/page.tsx" "src/app/api/admin/vendors/route.ts"`
+
+Verification note:
+- Targeted ESLint passed on all touched files.
+
+### 2026-04-13 - Mark Shipped now uses the same button layout as the timer actions
+- Updated `src/app/orders/[id]/page.tsx` so `Mark Shipped` is now a real outline button with the same size/layout treatment as `Start timer` and `Move Dept.` instead of a custom checkbox wrapper.
+- Added a small shipped-state icon and kept the same Shipping-only enable/disable behavior.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed.
+
+### 2026-04-13 - Shipping completion control renamed and aligned
+- Updated `src/app/orders/[id]/page.tsx` so the shipping-only completion control now reads `Mark Shipped` instead of `Complete in Shipping`.
+- Tightened the control wrapper so it uses the same centered, button-like alignment as the rest of the timer action row.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed.
+
+### 2026-04-13 - Active timer chips now own the stop action
+- Updated `src/app/orders/[id]/page.tsx` so each active timer chip now shows a small stop icon at the end of the chip.
+- Removed the separate `Stop` button from the main timer action row; stopping a timer from the part controls now happens by clicking the specific active timer chip for that worker.
+- This keeps the start action as the single main-row button and makes the stop affordance match the worker-specific timer chips.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed.
+
+### 2026-04-13 - Active timer chips now tick live and Read Me First shows acknowledgement roster
+- Updated `src/app/orders/[id]/page.tsx` so the active timer chip clock now refreshes from the selected part's `activeTimers` data instead of only from the logged-in user's `activeEntries`.
+- This fixes the shared-view case where another worker's timer chip stayed frozen until a full page refresh.
+- Added an `Already read by` list to the `Read me first` card that shows which users have acknowledged the current instruction version for the selected part's current department, along with acknowledgement timestamps.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+Verification note:
+- Targeted ESLint passed.
+
+### 2026-04-13 - Mission brief now supports selected-worker PIN acknowledgement and structured quote-note bullets
+- Updated `src/app/orders/[id]/page.tsx` so the mission-brief / required-reading flow now checks acknowledgement against the selected timer worker before opening the timer PIN dialog.
+- When that selected worker has not acknowledged the current part/department instructions yet, the mission-brief popup now:
+  - lets the operator choose the worker in the popup,
+  - requires that worker's PIN before recording the acknowledgement,
+  - carries the selected worker + PIN forward into the existing timer start dialog so the operator does not have to change identities in the browser session first.
+- Reworked mission-brief rendering on order detail so `workInstructions` now display as headed bullet sections instead of one flat text block wherever possible.
+- Updated quote-to-order instruction seeding in `src/app/orders/new/page.tsx` so newly converted orders now carry all of the original quote note-style fields into `workInstructions` as structured sections:
+  - `Quote requirements`,
+  - `Quote notes`,
+  - `Materials`,
+  - `Purchase items`,
+  - `Part-specific notes`.
+- Updated `src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts` so acknowledgement can be recorded for a selected worker after that worker's PIN is verified, instead of always forcing the logged-in browser user as the receipt owner.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx" "src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts"`
+
+Verification note:
+- Targeted ESLint passed on all touched files.
+
 ### 2026-04-13 - Timer tile now uses department + user selection before PIN start/stop
 - Updated `src/app/orders/[id]/page.tsx` so the main timer tile now presents:
   - department selector,

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -60,6 +60,14 @@ Goal: a scalable foundation that can grow.
 
 ## Decision Log (append newest at top)
 
+### 2026-04-13 - Completed parts keep their final department for queue visibility; department queue prioritizes active timers
+Decision: When a part reaches `COMPLETE`, preserve its final `currentDepartmentId` instead of clearing it to null, and have the department work queue sort orders with active timers ahead of the rest while showing order-level active timer chips on the card.
+Reason: Nulling the department makes completed/shipped work look unassigned and prevents the existing `Show completed items` filter from surfacing finished parts in the queue operators expect. Active timers are the hottest work on the floor, so they should rise to the top of department cards without changing the rest of the queue model.
+
+### 2026-04-13 - Mission-brief acknowledgement follows the selected timer worker; quote-derived instructions are sectioned bullet notes
+Decision: Keep checklist/submit acknowledgement browser-user based, but when the order-detail timer flow is starting work for a selected worker, require mission-brief acknowledgement against that selected worker and verify it with that worker's PIN; seed quote-derived `workInstructions` as headed bullet sections covering all original quote note-style fields.
+Reason: Shared floor stations can have one browser login while a different worker is actually starting the timer, so the acknowledgement receipt must belong to the worker who will own the timer. Structuring quote-derived instructions makes the required-reading popup scan like a real shop bulletin instead of a flat text wall.
+
 ### 2026-04-10 - Order detail is now the primary kiosk-timing entry for floor users
 Decision: Keep the kiosk session/PIN/timer APIs and `/kiosk` route, but move the primary worker-facing kiosk timing flow back into `/orders/[id]` by opening an in-page PIN + part-picker dialog from the order-detail timer area for kiosk-enabled machinists.
 Reason: Floor users already live in order detail while reviewing notes/files/checklists, so sending them to a separate kiosk page for the same timer action adds friction without changing the timer enforcement model.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,3 +1,184 @@
+## Session Handoff - 2026-04-13 (Queue priority + timer chips + Vendors pagination + completed department ownership)
+
+Goal (1 sentence): Surface active work more clearly on the dashboard, preserve finished parts under a visible department owner, and give the Vendors page real pagination controls.
+
+### What changed
+- Updated [orders.service.ts](C:/Users/user/Documents/GitHub/shopapp1/src/modules/orders/orders.service.ts)
+  - Department queue feed now enriches orders with active timer summaries and sorts active-timer orders to the top before the existing flagged/due ordering.
+  - Completed parts now preserve their final department ownership instead of clearing `currentDepartmentId` to `null`.
+  - This applies to both:
+    - shipping completion (`Mark Shipped`),
+    - final no-next-department submit completion.
+- Updated [WorkQueueOrderCard.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/components/work-queue/WorkQueueOrderCard.tsx)
+  - Order tiles in the department queue now show small green active timer chips with worker + elapsed time.
+- Updated [ShopFloorLayouts.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/components/ShopFloorLayouts.tsx)
+  - Renamed the department feed completed toggle label to `Show completed items`.
+- Updated Vendors admin pagination:
+  - [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/vendors/page.tsx)
+  - [client.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/vendors/client.tsx)
+  - [route.ts](C:/Users/user/Documents/GitHub/shopapp1/src/app/api/admin/vendors/route.ts)
+  - The Vendors list now uses page-based navigation with total count + `Previous` / `Next` buttons instead of one-way cursor loading.
+
+### Files touched
+- `src/modules/orders/orders.service.ts`
+- `src/modules/orders/orders.types.ts`
+- `src/components/work-queue/WorkQueueOrderCard.tsx`
+- `src/components/ShopFloorLayouts.tsx`
+- `src/app/admin/vendors/page.tsx`
+- `src/app/admin/vendors/client.tsx`
+- `src/app/api/admin/vendors/route.ts`
+- `tasks/todo.md`
+- `tasks/lessons.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+- `docs/AGENT_CONTEXT.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/components/ShopFloorLayouts.tsx" "src/components/work-queue/WorkQueueOrderCard.tsx" "src/modules/orders/orders.service.ts" "src/modules/orders/orders.types.ts" "src/app/admin/vendors/client.tsx" "src/app/admin/vendors/page.tsx" "src/app/api/admin/vendors/route.ts"`
+
+### Verification evidence
+- Targeted ESLint passed on all touched files.
+
+### Behavior note for the next agent
+- Completed parts now stay attached to their final department for queue/read-model purposes, which is what makes `Show completed items` useful on the dashboard.
+- Department queue timer chips are currently snapshot-based from the feed response; they are not live-updating yet.
+
+## Session Handoff - 2026-04-13 (Mark Shipped button parity fix)
+
+Goal (1 sentence): Make `Mark Shipped` use the same button size/layout pattern as the other timer-row actions instead of a custom wrapper.
+
+### What changed
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/[id]/page.tsx)
+  - Replaced the custom checkbox-style shipping control with a real outline button.
+  - Matched the same `size="sm"` / button layout pattern used by `Start timer` and `Move Dept.`.
+  - Added a small shipped-state icon while preserving the existing Shipping-only enable/disable behavior.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed.
+
+## Session Handoff - 2026-04-13 (Shipping action label + alignment polish)
+
+Goal (1 sentence): Rename the shipping-only completion control to `Mark Shipped` and make it line up visually with the other timer-row controls.
+
+### What changed
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/[id]/page.tsx)
+  - Renamed `Complete in Shipping` to `Mark Shipped`.
+  - Adjusted the control wrapper to use centered, button-like alignment so it sits in line with the other timer actions.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed.
+
+## Session Handoff - 2026-04-13 (Active timer chip stop affordance)
+
+Goal (1 sentence): Make active timer chips visually read like stop controls and remove the duplicate standalone stop button from the main timer row.
+
+### What changed
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/[id]/page.tsx)
+  - Added a small stop icon at the end of each active timer chip.
+  - Removed the separate `Stop` button from the main timer action row.
+  - The selected-part timer row now uses:
+    - chip click to stop a specific worker timer with that worker's PIN,
+    - main-row `Start timer` to begin work,
+    - no duplicate generic stop button.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed.
+
+## Session Handoff - 2026-04-13 (Live timer chips + instruction acknowledgement roster)
+
+Goal (1 sentence): Make the selected-part active timer chips update live without refresh and show who has already acknowledged the current Read Me First instructions.
+
+### What changed
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/[id]/page.tsx)
+  - Switched the 1-second client clock tick to follow `selectedPartActivity.activeTimers` rather than only the logged-in browser user's `activeEntries`.
+  - This keeps active timer chips live for shared/admin viewers even when they personally do not have an active timer.
+  - Added an `Already read by` roster to the `Read me first` card using the existing `instructionReceipts` payload for:
+    - current department,
+    - current instruction version,
+    - worker name,
+    - acknowledgement timestamp.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+### Verification evidence
+- Targeted ESLint passed.
+
+## Session Handoff - 2026-04-13 (Mission brief worker PIN follow-up + quote-note bulletin formatting)
+
+Goal (1 sentence): Make required-reading acknowledgement follow the selected timer worker instead of the browser session user, and present quote-derived part instructions as headed bullet sections rather than a flat text block.
+
+### What changed
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/[id]/page.tsx)
+  - Timer start now checks instruction acknowledgement against the selected worker + selected department before opening the timer start PIN dialog.
+  - If that worker still needs to acknowledge the brief, the mission-brief popup now shows:
+    - worker picker,
+    - worker PIN field.
+  - Successful acknowledgement now records the receipt for that selected worker and reopens the existing timer start dialog with that worker + PIN already carried forward.
+  - Mission-brief content and the overview `Part instructions` card now render structured sections as heading + bullet lists when the stored text follows the seeded section format.
+- Updated [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/new/page.tsx)
+  - Quote conversion now seeds `workInstructions` from all quote note-style fields as structured sections:
+    - `Quote requirements`,
+    - `Quote notes`,
+    - `Materials`,
+    - `Purchase items`,
+    - `Part-specific notes`.
+- Updated [route.ts](C:/Users/user/Documents/GitHub/shopapp1/src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts)
+  - The acknowledgement route now accepts an optional selected worker + PIN pair and records the receipt for that verified worker instead of forcing the logged-in browser session user.
+
+### Files touched
+- `src/app/orders/[id]/page.tsx`
+- `src/app/orders/new/page.tsx`
+- `src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts`
+- `tasks/todo.md`
+- `tasks/lessons.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+- `docs/AGENT_CONTEXT.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx" "src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts"`
+
+### Verification evidence
+- Targeted ESLint passed on all touched files.
+
+### Behavior note for the next agent
+- The mission-brief popup now lets the operator pick a worker; PIN is required whenever the acknowledgement is being recorded for someone other than the logged-in browser user. Checklist/submit completion paths still proceed as the logged-in browser user after the brief is acknowledged.
+- Newly converted orders will get the new headed-bullet instruction format automatically; older orders still render safely because the order-detail page now parses both the new sectioned format and older plain text blocks.
+
 ## Session Handoff - 2026-04-13 (Timer tile layout follow-up: dept + user + PIN flow)
 
 Goal (1 sentence): Match the requested timer-tile layout by making department and user selection happen in the tile, moving start/stop onto the PIN popup flow, fixing the department dropdown reset bug, renaming `Submit to` to `Move Dept.`, and restyling `Complete in Shipping` as a checkbox-style control.

--- a/src/app/admin/vendors/client.tsx
+++ b/src/app/admin/vendors/client.tsx
@@ -77,9 +77,11 @@ const EMPTY_IMPORT_MAPPING = {
   duplicateMode: 'skip' as 'skip' | 'update',
 };
 
-export default function Client({ initial }: { initial: { items?: Item[]; nextCursor?: string | null } }) {
+export default function Client({ initial }: { initial: { items?: Item[]; totalCount?: number; page?: number; pageSize?: number } }) {
   const [items, setItems] = useState<Item[]>(initial.items ?? []);
-  const [nextCursor, setNextCursor] = useState<string | null>(initial.nextCursor ?? null);
+  const [page, setPage] = useState<number>((initial as any).page ?? 1);
+  const [pageSize] = useState<number>((initial as any).pageSize ?? 20);
+  const [totalCount, setTotalCount] = useState<number>((initial as any).totalCount ?? (initial.items?.length ?? 0));
   const [query, setQuery] = useState('');
   const [dialog, setDialog] = useState<DialogState>(null);
   const [form, setForm] = useState({
@@ -146,13 +148,17 @@ export default function Client({ initial }: { initial: { items?: Item[]; nextCur
     }));
   }, [importPreview]);
 
-  async function refresh(cursor?: string) {
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
+
+  async function refresh(nextPage = page) {
     const qs = new URLSearchParams();
     if (query) qs.set('q', query);
-    if (cursor) qs.set('cursor', cursor);
-    const data = await fetchJson<{ items?: Item[]; nextCursor?: string | null }>('/api/admin/vendors?' + qs.toString());
-    setItems(cursor ? [...items, ...(data.items ?? [])] : data.items ?? []);
-    setNextCursor(data.nextCursor ?? null);
+    qs.set('page', String(nextPage));
+    qs.set('take', String(pageSize));
+    const data = await fetchJson<{ items?: Item[]; totalCount?: number; page?: number; pageSize?: number }>('/api/admin/vendors?' + qs.toString());
+    setItems(data.items ?? []);
+    setTotalCount(typeof data.totalCount === 'number' ? data.totalCount : 0);
+    setPage(typeof data.page === 'number' ? data.page : nextPage);
   }
 
   async function save() {
@@ -175,12 +181,12 @@ export default function Client({ initial }: { initial: { items?: Item[]; nextCur
         setItems(items.map((i) => (i.id === dialog.data?.id ? res.item : i)));
         toast.push('Vendor updated', 'success');
       } else {
-        const res = await fetchJson<{ item: Item }>('/api/admin/vendors', {
+        await fetchJson<{ item: Item }>('/api/admin/vendors', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify(payload),
         });
-        setItems([res.item, ...items]);
+        await refresh(1);
         toast.push('Vendor created', 'success');
       }
       setDialog(null);
@@ -191,7 +197,8 @@ export default function Client({ initial }: { initial: { items?: Item[]; nextCur
 
   async function remove(row: Item) {
     await fetchJson('/api/admin/vendors/' + row.id, { method: 'DELETE' });
-    setItems(items.filter((i) => i.id !== row.id));
+    const nextPage = Math.max(1, page);
+    await refresh(nextPage);
     toast.push('Vendor deleted', 'success');
   }
 
@@ -247,7 +254,7 @@ export default function Client({ initial }: { initial: { items?: Item[]; nextCur
         setImportResult(null);
       } else {
         setImportResult(body as ImportResult);
-        await refresh();
+        await refresh(1);
         toast.push('Vendor import complete', 'success');
       }
     } catch (error: any) {
@@ -648,7 +655,7 @@ export default function Client({ initial }: { initial: { items?: Item[]; nextCur
             placeholder="Search"
             className="w-full max-w-xs"
           />
-          <Button variant="outline" onClick={() => refresh()}>
+          <Button variant="outline" onClick={() => void refresh(1)}>
             Search
           </Button>
           <div className="flex-1" />
@@ -663,13 +670,19 @@ export default function Client({ initial }: { initial: { items?: Item[]; nextCur
           actionsEnabled={isAdmin}
         />
 
-        {nextCursor && (
-          <div className="flex justify-center">
-            <Button variant="outline" onClick={() => refresh(nextCursor)}>
-              Load more
+        <div className="flex flex-wrap items-center justify-between gap-3 text-sm text-muted-foreground">
+          <span>
+            Page {page} of {totalPages} · {totalCount} vendor{totalCount === 1 ? '' : 's'}
+          </span>
+          <div className="flex items-center gap-2">
+            <Button variant="outline" disabled={page <= 1} onClick={() => void refresh(page - 1)}>
+              Previous
+            </Button>
+            <Button variant="outline" disabled={page >= totalPages} onClick={() => void refresh(page + 1)}>
+              Next
             </Button>
           </div>
-        )}
+        </div>
       </div>
 
       <Dialog open={dialog !== null} onOpenChange={(open) => !open && setDialog(null)}>

--- a/src/app/admin/vendors/page.tsx
+++ b/src/app/admin/vendors/page.tsx
@@ -6,8 +6,12 @@ import { prisma } from '@/lib/prisma';
 export const dynamic = 'force-dynamic';
 
 export default async function Page() {
-  const items = await prisma.vendor.findMany({ orderBy: { id: 'asc' }, take: 20 });
-  const initial = { items, nextCursor: null };
+  const pageSize = 20;
+  const [items, totalCount] = await Promise.all([
+    prisma.vendor.findMany({ orderBy: { id: 'asc' }, take: pageSize }),
+    prisma.vendor.count(),
+  ]);
+  const initial = { items, totalCount, page: 1, pageSize };
   return (
     <div className="p-4 text-neutral-100">
       <NavTabs />

--- a/src/app/api/admin/vendors/route.ts
+++ b/src/app/api/admin/vendors/route.ts
@@ -28,8 +28,9 @@ export async function GET(req: NextRequest) {
   if (guard) return guard;
   const { searchParams } = new URL(req.url);
   const q = searchParams.get('q') || undefined;
-  const cursor = searchParams.get('cursor');
-  const take = Number(searchParams.get('take') || '20');
+  const page = Math.max(1, Number(searchParams.get('page') || '1'));
+  const take = Math.min(100, Math.max(1, Number(searchParams.get('take') || '20')));
+  const skip = (page - 1) * take;
 
   const where = q
     ? ({
@@ -43,15 +44,16 @@ export async function GET(req: NextRequest) {
         ],
       } as any)
     : undefined;
-  const items = await prisma.vendor.findMany({
-    where,
-    orderBy: { id: 'asc' },
-    take: take + 1,
-    ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),
-  });
-  const nextCursor = items.length > take ? (items[take] as any).id : null;
-  if (nextCursor) items.pop();
-  return NextResponse.json({ items, nextCursor });
+  const [items, totalCount] = await Promise.all([
+    prisma.vendor.findMany({
+      where,
+      orderBy: { id: 'asc' },
+      skip,
+      take,
+    }),
+    prisma.vendor.count({ where }),
+  ]);
+  return NextResponse.json({ items, totalCount, page, pageSize: take });
 }
 
 export async function POST(req: NextRequest) {

--- a/src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts
+++ b/src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getServerAuthSession } from '@/lib/auth-session';
 import { canAccessMachinist } from '@/lib/rbac';
+import { unlockKioskByWorkerPin } from '@/modules/kiosk/kiosk.service';
 import { acknowledgePartInstructions, getPartInstructionStatus } from '@/modules/orders/orders.service';
 
 export async function GET(
@@ -39,15 +40,32 @@ export async function POST(
   const { id, partId } = await params;
   const body = await req.json().catch(() => null);
   const departmentId = typeof body?.departmentId === 'string' ? body.departmentId.trim() : '';
+  const requestedWorkerId = typeof body?.workerId === 'string' ? body.workerId.trim() : '';
+  const workerPin = typeof body?.pin === 'string' ? body.pin.trim() : '';
   if (!departmentId) {
     return NextResponse.json({ error: 'departmentId is required.' }, { status: 400 });
+  }
+
+  let acknowledgementUserId = (session.user as any)?.id as string;
+  if (requestedWorkerId) {
+    if (!workerPin) {
+      return NextResponse.json({ error: 'pin is required when workerId is provided.' }, { status: 400 });
+    }
+    const unlockResult = await unlockKioskByWorkerPin({
+      userId: requestedWorkerId,
+      pin: workerPin,
+    });
+    if (unlockResult.ok === false) {
+      return NextResponse.json({ error: unlockResult.error }, { status: unlockResult.status });
+    }
+    acknowledgementUserId = requestedWorkerId;
   }
 
   const result = await acknowledgePartInstructions({
     orderId: id,
     partId,
     departmentId,
-    userId: (session.user as any)?.id as string,
+    userId: acknowledgementUserId,
   });
   if (result.ok === false) {
     return NextResponse.json({ error: result.error }, { status: result.status });

--- a/src/app/orders/[id]/page.tsx
+++ b/src/app/orders/[id]/page.tsx
@@ -86,6 +86,8 @@ type InstructionGateDialogState = {
   loading: boolean;
   error: string | null;
   pendingAction: InstructionGatePendingAction | null;
+  workerId: string;
+  pin: string;
 };
 type ChecklistPerformerDialogState = {
   open: boolean;
@@ -132,6 +134,50 @@ const statusBadgeStyles: Record<string, string> = {
   COMPLETE: 'bg-emerald-500/15 text-emerald-200',
   IN_PROGRESS: 'bg-blue-500/15 text-blue-200',
   CLOSED: 'bg-slate-500/20 text-slate-200',
+};
+
+type InstructionSection = {
+  heading: string | null;
+  items: string[];
+};
+
+const parseInstructionSections = (instructions: string): InstructionSection[] => {
+  const blocks = instructions
+    .split(/\r?\n\s*\r?\n/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  const sections = blocks
+    .map((block) => {
+      const rawLines = block
+        .split(/\r?\n/)
+        .map((line) => line.trim())
+        .filter(Boolean);
+      if (!rawLines.length) return null;
+
+      const firstLine = rawLines[0];
+      const hasHeading = firstLine.endsWith(':');
+      const heading = hasHeading ? firstLine.slice(0, -1).trim() || null : null;
+      const itemSource = hasHeading ? rawLines.slice(1) : rawLines;
+      const items = itemSource
+        .map((line) => line.replace(/^[-*•]\s*/, '').trim())
+        .filter(Boolean);
+
+      if (!items.length && heading) {
+        return { heading, items: ['No details provided.'] };
+      }
+      if (!items.length) return null;
+
+      return {
+        heading,
+        items,
+      };
+    })
+    .filter(Boolean) as InstructionSection[];
+
+  if (sections.length) return sections;
+  const fallback = instructions.trim();
+  return fallback ? [{ heading: null, items: [fallback] }] : [];
 };
 
 export default function OrderDetailPage() {
@@ -234,6 +280,8 @@ export default function OrderDetailPage() {
     loading: false,
     error: null,
     pendingAction: null,
+    workerId: '',
+    pin: '',
   });
   const [checklistPerformerDialog, setChecklistPerformerDialog] = useState<ChecklistPerformerDialogState>({
     open: false,
@@ -282,20 +330,28 @@ export default function OrderDetailPage() {
     currentUserId ||
     'Current user';
   const selectedPartInstructions = String(selectedPart?.workInstructions ?? '').trim();
+  const selectedPartInstructionSections = useMemo(
+    () => parseInstructionSections(selectedPartInstructions),
+    [selectedPartInstructions],
+  );
   const selectedPartInstructionsVersion = Math.max(1, Number(selectedPart?.instructionsVersion ?? 1));
   const selectedPartCurrentDepartmentId = selectedPart?.currentDepartmentId ?? null;
-  const selectedPartInstructionReceipt = useMemo(() => {
-    if (!selectedPartId || !currentUserId || !selectedPartCurrentDepartmentId) return null;
+  const getInstructionReceiptForUserDepartment = (userId?: string | null, departmentId?: string | null) => {
+    if (!selectedPartId || !userId || !departmentId) return null;
     const receipts = Array.isArray(selectedPart?.instructionReceipts) ? selectedPart.instructionReceipts : [];
     return (
       receipts.find(
         (receipt: any) =>
-          receipt.userId === currentUserId &&
-          receipt.departmentId === selectedPartCurrentDepartmentId &&
+          receipt.userId === userId &&
+          receipt.departmentId === departmentId &&
           Math.max(1, Number(receipt.instructionsVersion ?? 1)) === selectedPartInstructionsVersion,
       ) ?? null
     );
-  }, [currentUserId, selectedPart, selectedPartCurrentDepartmentId, selectedPartId, selectedPartInstructionsVersion]);
+  };
+  const selectedPartInstructionReceipt = getInstructionReceiptForUserDepartment(
+    currentUserId,
+    selectedPartCurrentDepartmentId,
+  );
   const selectedPartRequiresInstructionGate = Boolean(selectedPartInstructions && selectedPartCurrentDepartmentId && !selectedPartInstructionReceipt);
   const selectedPartAssignments = useMemo(() => (Array.isArray(selectedPart?.assignments) ? selectedPart.assignments : []), [selectedPart?.assignments]);
   const assignedWorkerIds = useMemo(() => new Set(selectedPartAssignments.map((assignment: any) => assignment.userId)), [selectedPartAssignments]);
@@ -336,6 +392,10 @@ export default function OrderDetailPage() {
     () => timerWorkerOptions.find((user) => user.id === selectedTimerWorkerId) ?? null,
     [selectedTimerWorkerId, timerWorkerOptions],
   );
+  const selectedInstructionGateWorker = useMemo(
+    () => timerWorkerOptions.find((user) => user.id === instructionGateDialog.workerId) ?? null,
+    [instructionGateDialog.workerId, timerWorkerOptions],
+  );
   const selectedChecklist = useMemo(() => {
     if (!selectedPartId) return [];
     const items = Array.isArray(item?.checklist) ? item.checklist : [];
@@ -363,10 +423,29 @@ export default function OrderDetailPage() {
 
   const manualMoveDepartments = useMemo(() => departments, [departments]);
   const selectedCurrentDepartment = manualMoveDepartments.find((department) => department.id === selectedPart?.currentDepartmentId) ?? null;
+  const instructionGateSupportsWorkerSelection =
+    !instructionGateDialog.pendingAction || instructionGateDialog.pendingAction.kind === 'timer-start';
+  const instructionGateDepartmentId = !instructionGateDialog.pendingAction
+    ? selectedPartCurrentDepartmentId
+    : instructionGateDialog.pendingAction.kind === 'timer-start'
+      ? selectedTimerDepartmentId || selectedPartCurrentDepartmentId
+      : instructionGateDialog.pendingAction.kind === 'checklist-toggle'
+        ? instructionGateDialog.pendingAction.entry?.departmentId ?? selectedPartCurrentDepartmentId
+        : selectedPartCurrentDepartmentId;
+  const instructionGateDepartment = manualMoveDepartments.find((department) => department.id === instructionGateDepartmentId) ?? null;
   const submitDestinationOptions = useMemo(
     () => manualMoveDepartments.filter((department) => department.id !== selectedPart?.currentDepartmentId),
     [manualMoveDepartments, selectedPart?.currentDepartmentId]
   );
+  const selectedPartAcknowledgedReceipts = useMemo(() => {
+    const receipts = Array.isArray(selectedPart?.instructionReceipts) ? selectedPart.instructionReceipts : [];
+    if (!selectedPartCurrentDepartmentId) return [];
+    return receipts.filter(
+      (receipt: any) =>
+        receipt?.departmentId === selectedPartCurrentDepartmentId &&
+        Math.max(1, Number(receipt?.instructionsVersion ?? 1)) === selectedPartInstructionsVersion,
+    );
+  }, [selectedPart?.instructionReceipts, selectedPartCurrentDepartmentId, selectedPartInstructionsVersion]);
 
   const selectedPartDepartmentHistory = useMemo(() => {
     if (!selectedPartId) return [];
@@ -444,6 +523,11 @@ export default function OrderDetailPage() {
     () => PART_TABS.filter((tab) => (tab === 'full-files' ? canEditParts : true)),
     [canEditParts]
   );
+  const selectedPartActiveTimerCount = selectedPartId
+    ? Array.isArray(partActivity[selectedPartId]?.activeTimers)
+      ? partActivity[selectedPartId].activeTimers.length
+      : 0
+    : 0;
 
   const selectedActiveEntry = useMemo(
     () =>
@@ -461,11 +545,11 @@ export default function OrderDetailPage() {
   }, [partEvents]);
 
   useEffect(() => {
-    const interval = activeEntries.length ? window.setInterval(() => setNowMs(Date.now()), 1000) : null;
+    const interval = selectedPartActiveTimerCount ? window.setInterval(() => setNowMs(Date.now()), 1000) : null;
     return () => {
       if (interval) window.clearInterval(interval);
     };
-  }, [activeEntries.length]);
+  }, [selectedPartActiveTimerCount]);
 
   const load = React.useCallback(async () => {
     if (!id) return null;
@@ -737,15 +821,15 @@ export default function OrderDetailPage() {
   }, [loadPartEvents]);
 
   const isInstructionAcknowledgedForDepartment = (departmentId?: string | null) => {
+    return isInstructionAcknowledgedForUserDepartment(currentUserId, departmentId);
+  };
+
+  const isInstructionAcknowledgedForUserDepartment = (
+    userId?: string | null,
+    departmentId?: string | null,
+  ) => {
     if (!selectedPartInstructions) return true;
-    if (!selectedPartId || !departmentId || !currentUserId) return !selectedPartInstructions;
-    const receipts = Array.isArray(selectedPart?.instructionReceipts) ? selectedPart.instructionReceipts : [];
-    return receipts.some(
-      (receipt: any) =>
-        receipt.userId === currentUserId &&
-        receipt.departmentId === departmentId &&
-        Math.max(1, Number(receipt.instructionsVersion ?? 1)) === selectedPartInstructionsVersion,
-    );
+    return Boolean(getInstructionReceiptForUserDepartment(userId, departmentId));
   };
 
   const buildInstructionGateAction = (pendingAction: InstructionGatePendingAction) => {
@@ -755,6 +839,28 @@ export default function OrderDetailPage() {
       loading: false,
       error: null,
       pendingAction,
+      workerId:
+        pendingAction.kind === 'timer-start'
+          ? selectedTimerWorkerId || currentUserId || timerWorkerOptions[0]?.id || ''
+          : currentUserId || timerWorkerOptions[0]?.id || '',
+      pin: '',
+    });
+  };
+
+  const continueTimerStartAfterInstructionGate = ({ workerId, pin = '' }: { workerId: string; pin?: string }) => {
+    if (!selectedPartId || !selectedTimerDepartmentId) return;
+    openKioskTimerDialog('start', {
+      workerId,
+      departmentId: selectedTimerDepartmentId,
+      partId: selectedPartId,
+      pin,
+      targetTimer: {
+        userName: timerWorkerOptions.find((user) => user.id === workerId)?.name || 'Worker',
+        departmentName:
+          timerDepartments.find((department) => department.id === selectedTimerDepartmentId)?.name ??
+          selectedTimerDepartmentId,
+        partLabel: selectedPart?.partNumber || 'Selected part',
+      },
     });
   };
 
@@ -783,9 +889,14 @@ export default function OrderDetailPage() {
         loading: false,
         error: null,
         pendingAction: null,
+        workerId: '',
+        pin: '',
       });
       if (pendingAction?.kind === 'timer-start') {
-        await handleStart({ skipInstructionGate: true });
+        continueTimerStartAfterInstructionGate({
+          workerId: instructionGateDialog.workerId || selectedTimerWorkerId,
+          pin: instructionGateDialog.pin,
+        });
       } else if (pendingAction?.kind === 'checklist-toggle') {
         setChecklistPerformerDialog({
           open: true,
@@ -806,6 +917,28 @@ export default function OrderDetailPage() {
       return;
     }
 
+    const timerStartWorkerId =
+      pendingAction?.kind === 'timer-start'
+        ? instructionGateDialog.workerId.trim() || selectedTimerWorkerId
+        : '';
+    const timerStartPin = pendingAction?.kind === 'timer-start' ? instructionGateDialog.pin.trim() : '';
+    const manualAckWorkerId = !pendingAction ? instructionGateDialog.workerId.trim() : '';
+    const manualAckPin = !pendingAction ? instructionGateDialog.pin.trim() : '';
+    const acknowledgementWorkerId = timerStartWorkerId || manualAckWorkerId;
+    const acknowledgementPin = timerStartPin || manualAckPin;
+    if (pendingAction?.kind === 'timer-start' && !timerStartWorkerId) {
+      setInstructionGateDialog((prev) => ({ ...prev, error: 'Choose the worker who read these instructions.' }));
+      return;
+    }
+    if (pendingAction?.kind === 'timer-start' && !timerStartPin) {
+      setInstructionGateDialog((prev) => ({ ...prev, error: "Enter that worker's PIN to confirm the acknowledgement." }));
+      return;
+    }
+    if (!pendingAction && acknowledgementWorkerId && acknowledgementWorkerId !== currentUserId && !acknowledgementPin) {
+      setInstructionGateDialog((prev) => ({ ...prev, error: "Enter that worker's PIN to confirm the acknowledgement." }));
+      return;
+    }
+
     setInstructionGateDialog((prev) => ({ ...prev, loading: true, error: null }));
     try {
       const dismissKey = selectedPartId && selectedPartCurrentDepartmentId
@@ -817,6 +950,8 @@ export default function OrderDetailPage() {
         credentials: 'include',
         body: JSON.stringify({
           departmentId,
+          workerId: acknowledgementWorkerId || undefined,
+          pin: acknowledgementPin || undefined,
         }),
       });
       if (!res.ok) {
@@ -829,12 +964,17 @@ export default function OrderDetailPage() {
         loading: false,
         error: null,
         pendingAction: null,
+        workerId: '',
+        pin: '',
       });
       setDismissedInstructionGateKey(dismissKey);
       toast.push('Instructions acknowledged.', 'success');
 
       if (pendingAction?.kind === 'timer-start') {
-        await handleStart({ skipInstructionGate: true });
+        continueTimerStartAfterInstructionGate({
+          workerId: timerStartWorkerId,
+          pin: timerStartPin,
+        });
       } else if (pendingAction?.kind === 'checklist-toggle') {
         setChecklistPerformerDialog({
           open: true,
@@ -969,6 +1109,7 @@ export default function OrderDetailPage() {
       workerId?: string;
       departmentId?: string;
       partId?: string;
+      pin?: string;
       targetTimer?: {
         userName: string;
         departmentName: string | null;
@@ -992,7 +1133,7 @@ export default function OrderDetailPage() {
       mode,
       workerId: defaultWorkerId,
       departmentId: defaultDepartmentId,
-      pin: '',
+      pin: options?.pin ?? '',
       partId: options?.partId ?? selectedPartId ?? parts[0]?.id ?? '',
       loading: false,
       error: null,
@@ -1305,6 +1446,10 @@ export default function OrderDetailPage() {
       setTimerError('Choose a user first.');
       return;
     }
+    if (!isInstructionAcknowledgedForUserDepartment(selectedTimerWorkerId, selectedTimerDepartmentId)) {
+      buildInstructionGateAction({ kind: 'timer-start' });
+      return;
+    }
     setTimerError(null);
     openKioskTimerDialog('start', {
       workerId: selectedTimerWorkerId,
@@ -1318,15 +1463,6 @@ export default function OrderDetailPage() {
         partLabel: selectedPart?.partNumber || 'Selected part',
       },
     });
-  };
-
-  const handleOpenSelectedTimerStopDialog = () => {
-    if (!selectedWorkerPartActiveTimer) {
-      setTimerError('The selected user does not have an active timer on this part for that department.');
-      return;
-    }
-    setTimerError(null);
-    handleOpenActiveTimerChip(selectedWorkerPartActiveTimer);
   };
 
   const openMoveDepartmentDialog = () => {
@@ -1847,8 +1983,11 @@ export default function OrderDetailPage() {
       loading: false,
       error: null,
       pendingAction: null,
+      workerId: currentUserId || timerWorkerOptions[0]?.id || '',
+      pin: '',
     });
   }, [
+    currentUserId,
     checklistPerformerDialog.open,
     dismissedInstructionGateKey,
     instructionGateDialog.open,
@@ -1858,6 +1997,7 @@ export default function OrderDetailPage() {
     selectedPartInstructions,
     selectedPartInstructionsVersion,
     submitConfirmDialog.open,
+    timerWorkerOptions,
   ]);
 
   useEffect(() => {
@@ -1959,12 +2099,6 @@ export default function OrderDetailPage() {
     ? selectedPartActivity.activeTimers
     : [];
   const activeOnSelected = selectedPartActiveTimers.length > 0;
-  const selectedWorkerPartActiveTimer =
-    selectedPartActiveTimers.find((entry: any) => {
-      if (!selectedTimerWorkerId || entry?.userId !== selectedTimerWorkerId) return false;
-      if (!selectedTimerDepartmentId) return true;
-      return entry?.departmentId === selectedTimerDepartmentId;
-    }) ?? null;
   const selectedPartTimerSeconds = selectedPartId ? partTotals[selectedPartId] ?? 0 : 0;
   const selectedPartManualSeconds = selectedPartId ? manualPartTotals[selectedPartId] ?? 0 : 0;
   const selectedPartStoredSeconds = selectedPartTimerSeconds + selectedPartManualSeconds;
@@ -2354,6 +2488,8 @@ export default function OrderDetailPage() {
                   loading: false,
                   error: null,
                   pendingAction: null,
+                  workerId: '',
+                  pin: '',
                 },
           );
         }}
@@ -2369,15 +2505,85 @@ export default function OrderDetailPage() {
             <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-3 text-sm text-foreground">
               Read this before you start work, check a checklist item, or submit the part forward. Your acknowledgement is recorded for this part and department.
             </div>
-            <div className="max-h-64 overflow-auto rounded-md border border-border/60 bg-muted/10 p-3 text-sm whitespace-pre-wrap text-foreground">
-              {selectedPartInstructions || 'No part-specific instructions were found for this part.'}
+            <div className="max-h-72 overflow-auto rounded-md border border-border/60 bg-muted/10 p-3 text-sm text-foreground">
+              {selectedPartInstructionSections.length ? (
+                <div className="space-y-4">
+                  {selectedPartInstructionSections.map((section, index) => (
+                    <div key={`${section.heading ?? 'notes'}-${index}`} className="space-y-2">
+                      {section.heading ? (
+                        <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                          {section.heading}
+                        </div>
+                      ) : null}
+                      <ul className="list-disc space-y-1 pl-5">
+                        {section.items.map((item, itemIndex) => (
+                          <li key={`${index}-${itemIndex}`} className="leading-6 text-foreground">
+                            {item}
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  ))}
+                </div>
+              ) : (
+                'No part-specific instructions were found for this part.'
+              )}
             </div>
+            {instructionGateSupportsWorkerSelection ? (
+              <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_220px]">
+                <div className="space-y-2">
+                  <Label htmlFor="instruction-gate-worker">Worker confirming this brief</Label>
+                  <Select
+                    value={instructionGateDialog.workerId || '__none__'}
+                    onValueChange={(value) =>
+                      setInstructionGateDialog((prev) => ({
+                        ...prev,
+                        workerId: value === '__none__' ? '' : value,
+                      }))
+                    }
+                  >
+                    <SelectTrigger id="instruction-gate-worker" className="h-10 border-border/60 bg-background/80">
+                      <SelectValue placeholder="Select user" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="__none__">Select user</SelectItem>
+                      {timerWorkerOptions.map((user) => (
+                        <SelectItem key={user.id} value={user.id}>
+                          {user.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="instruction-gate-pin">Worker PIN</Label>
+                  <Input
+                    id="instruction-gate-pin"
+                    type="password"
+                    inputMode="numeric"
+                    autoComplete="one-time-code"
+                    value={instructionGateDialog.pin}
+                    onChange={(e) =>
+                      setInstructionGateDialog((prev) => ({
+                        ...prev,
+                        pin: e.target.value.replace(/\D+/g, '').slice(0, 12),
+                      }))
+                    }
+                    placeholder={
+                      selectedInstructionGateWorker
+                        ? `Enter ${selectedInstructionGateWorker.name}'s PIN`
+                        : 'Enter worker PIN'
+                    }
+                  />
+                </div>
+              </div>
+            ) : null}
             <div className="flex flex-wrap gap-2 text-xs">
               <span className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-foreground">
                 Part: {selectedPart?.partNumber || 'Selected part'}
               </span>
               <span className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-foreground">
-                Department: {selectedCurrentDepartment?.name ?? 'Current department'}
+                Department: {instructionGateDepartment?.name ?? 'Current department'}
               </span>
               <span className="rounded-full border border-border/60 bg-background/80 px-3 py-1 text-foreground">
                 Instruction version: {selectedPartInstructionsVersion}
@@ -2399,6 +2605,8 @@ export default function OrderDetailPage() {
                   loading: false,
                   error: null,
                   pendingAction: null,
+                  workerId: '',
+                  pin: '',
                 });
                 if (selectedPartId && selectedPartCurrentDepartmentId) {
                   setDismissedInstructionGateKey(
@@ -2691,7 +2899,8 @@ export default function OrderDetailPage() {
                               className="h-8 border-emerald-500/30 bg-emerald-500/10 px-2 text-[11px] text-emerald-100 hover:bg-emerald-500/20 hover:text-emerald-50"
                               onClick={() => handleOpenActiveTimerChip(entry)}
                             >
-                              {workerName}, {departmentName}, {formatDuration(elapsedSeconds)}
+                              <span>{workerName}, {departmentName}, {formatDuration(elapsedSeconds)}</span>
+                              <Square className="ml-2 h-3.5 w-3.5 opacity-80" />
                             </Button>
                           );
                         })
@@ -2704,8 +2913,8 @@ export default function OrderDetailPage() {
                         Click a timer to stop it with that worker&apos;s PIN.
                       </div>
                     ) : null}
-                  </div>
-                ) : null}
+                      </div>
+                    ) : null}
 
                 <div className="grid gap-2 md:grid-cols-2">
                   <Select value={selectedTimerDepartmentId} onValueChange={setSelectedTimerDepartmentId}>
@@ -2735,7 +2944,7 @@ export default function OrderDetailPage() {
                   </Select>
                 </div>
 
-                <div className="grid gap-2 lg:grid-cols-[repeat(3,minmax(0,1fr))_220px]">
+                <div className="grid gap-2 lg:grid-cols-[repeat(2,minmax(0,1fr))_220px]">
                   <Button
                     type="button"
                     size="sm"
@@ -2749,17 +2958,6 @@ export default function OrderDetailPage() {
                   <Button
                     type="button"
                     size="sm"
-                    variant="secondary"
-                    disabled={!selectedWorkerPartActiveTimer || timerSaving || kioskSessionLoading}
-                    onClick={handleOpenSelectedTimerStopDialog}
-                    className="justify-center gap-2"
-                  >
-                    <Square className="h-4 w-4" />
-                    Stop
-                  </Button>
-                  <Button
-                    type="button"
-                    size="sm"
                     variant="outline"
                     disabled={!selectedPartId || timerSaving || !submitDestinationOptions.length}
                     onClick={openMoveDepartmentDialog}
@@ -2768,24 +2966,21 @@ export default function OrderDetailPage() {
                     <ArrowRightLeft className="h-4 w-4" />
                     Move Dept.
                   </Button>
-                  <label
-                    className={`flex h-10 items-center gap-3 rounded-md border px-3 text-sm ${
-                      !selectedPartId || timerSaving || !canMarkPartComplete
-                        ? 'cursor-not-allowed border-border/40 bg-muted/30 text-muted-foreground'
-                        : 'cursor-pointer border-border/60 bg-background/80 text-foreground hover:bg-muted/20'
-                    }`}
+                  <Button
+                    type="button"
+                    size="sm"
+                    variant="outline"
+                    disabled={!selectedPartId || timerSaving || !canMarkPartComplete}
+                    onClick={() => {
+                      if (selectedPartId && !timerSaving && canMarkPartComplete) {
+                        void handleCompleteSelectedPart();
+                      }
+                    }}
+                    className="justify-center gap-2"
                   >
-                    <Checkbox
-                      checked={false}
-                      disabled={!selectedPartId || timerSaving || !canMarkPartComplete}
-                      onCheckedChange={(checked) => {
-                        if (checked === true && selectedPartId && !timerSaving && canMarkPartComplete) {
-                          void handleCompleteSelectedPart();
-                        }
-                      }}
-                    />
-                    <span>Complete in Shipping</span>
-                  </label>
+                    <CheckCircle2 className="h-4 w-4" />
+                    <span>Mark Shipped</span>
+                  </Button>
                 </div>
 
                 <div className="flex flex-wrap items-center justify-between gap-3 text-xs text-muted-foreground">
@@ -2822,13 +3017,13 @@ export default function OrderDetailPage() {
                       ) : null}
                     </div>
                     {selectedPartId ? (
-                  <div className="rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
+                      <div className="rounded-md border border-border/60 bg-muted/10 px-3 py-2 text-xs text-muted-foreground">
                     <div><span className="font-medium text-foreground">Total time:</span> {formatDuration(selectedPartStoredSeconds)}</div>
                     <div>Timer time: {formatDuration(selectedPartTimerSeconds)}</div>
                     <div className="flex items-center justify-between gap-3">
                       <span>Manual added time: {formatDuration(selectedPartManualSeconds)}</span>
                     </div>
-                    {showTimerDetails && partManualAdjustments.length ? (
+                        {partManualAdjustments.length ? (
                       <div className="mt-2 space-y-1">
                         {partManualAdjustments.map((adjustment: any) => (
                           <div key={adjustment.id}>
@@ -2837,7 +3032,7 @@ export default function OrderDetailPage() {
                         ))}
                       </div>
                     ) : null}
-                    {showTimerDetails && selectedPartDepartmentHistory.length ? (
+                        {selectedPartDepartmentHistory.length ? (
                       <div className="mt-3 space-y-2">
                         <div className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">Department history totals</div>
                         <div className="grid gap-2 md:grid-cols-2">
@@ -2865,16 +3060,16 @@ export default function OrderDetailPage() {
                     ) : null}
                   </div>
                 ) : null}
-                <div className="text-xs text-muted-foreground">
-                  {lastPartEvent ? (
-                    <span>
+                    <div className="text-xs text-muted-foreground">
+                      {lastPartEvent ? (
+                        <span>
                       Last action: <span className="font-medium text-foreground">{lastPartEvent.message}</span> ·{' '}
-                      {new Date(lastPartEvent.createdAt).toLocaleString()}
-                    </span>
-                  ) : (
-                    <span>Last action: none yet for this part.</span>
-                  )}
-                </div>
+                          {new Date(lastPartEvent.createdAt).toLocaleString()}
+                        </span>
+                      ) : (
+                        <span>Last action: none yet for this part.</span>
+                      )}
+                    </div>
                   </>
                 )}
               </div>
@@ -2980,14 +3175,61 @@ export default function OrderDetailPage() {
                       </span>
                     </div>
                     {selectedPartInstructions ? (
-                      <div className="rounded-md border border-border/60 bg-background/70 p-3 text-sm whitespace-pre-wrap text-foreground">
-                        {selectedPartInstructions}
+                      <div className="rounded-md border border-border/60 bg-background/70 p-3 text-sm text-foreground">
+                        <div className="space-y-4">
+                          {selectedPartInstructionSections.map((section, index) => (
+                            <div key={`${section.heading ?? 'notes'}-${index}`} className="space-y-2">
+                              {section.heading ? (
+                                <div className="text-[11px] font-semibold uppercase tracking-[0.14em] text-muted-foreground">
+                                  {section.heading}
+                                </div>
+                              ) : null}
+                              <ul className="list-disc space-y-1 pl-5">
+                                {section.items.map((item, itemIndex) => (
+                                  <li key={`${index}-${itemIndex}`} className="leading-6 text-foreground">
+                                    {item}
+                                  </li>
+                                ))}
+                              </ul>
+                            </div>
+                          ))}
+                        </div>
                       </div>
                     ) : (
                       <div className="rounded-md border border-dashed border-border/70 bg-background/60 p-3 text-sm text-muted-foreground">
                         No part-specific instructions were entered for this job.
                       </div>
                     )}
+                    <div className="space-y-2 rounded-md border border-border/60 bg-background/60 p-3">
+                      <div className="text-xs uppercase tracking-wide text-muted-foreground">Already read by</div>
+                      {selectedPartAcknowledgedReceipts.length ? (
+                        <div className="space-y-2">
+                          {selectedPartAcknowledgedReceipts.map((receipt: any) => {
+                            const workerName =
+                              receipt?.user?.name?.trim() ||
+                              receipt?.user?.email?.trim() ||
+                              receipt?.userId ||
+                              'Worker';
+                            const acknowledgedAtLabel = receipt?.acknowledgedAt
+                              ? new Date(receipt.acknowledgedAt).toLocaleString()
+                              : 'Time unavailable';
+                            return (
+                              <div
+                                key={receipt?.id ?? `${receipt?.userId ?? workerName}-${receipt?.acknowledgedAt ?? ''}`}
+                                className="flex flex-wrap items-center justify-between gap-2 rounded-md border border-border/50 bg-muted/10 px-3 py-2 text-sm"
+                              >
+                                <span className="font-medium text-foreground">{workerName}</span>
+                                <span className="text-xs text-muted-foreground">{acknowledgedAtLabel}</span>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      ) : (
+                        <div className="text-sm text-muted-foreground">
+                          Nobody has acknowledged this version for {selectedCurrentDepartment?.name ?? 'this department'} yet.
+                        </div>
+                      )}
+                    </div>
                     <div className="flex flex-wrap items-center gap-2">
                       <Button
                         type="button"
@@ -2999,6 +3241,8 @@ export default function OrderDetailPage() {
                             loading: false,
                             error: null,
                             pendingAction: null,
+                            workerId: currentUserId || timerWorkerOptions[0]?.id || '',
+                            pin: '',
                           })
                         }
                         disabled={!selectedPartInstructions || !selectedPartCurrentDepartmentId}

--- a/src/app/orders/new/page.tsx
+++ b/src/app/orders/new/page.tsx
@@ -151,11 +151,25 @@ const buildConversionNote = (quote: any) => {
 };
 
 const buildConversionWorkInstructions = (quote: any, part: any) => {
-  const sections: string[] = [];
-  const quoteRequirements = typeof quote?.requirements === 'string' ? quote.requirements.trim() : '';
-  const partSpecificNote = typeof part?.notes === 'string' ? part.notes.trim() : '';
-  if (quoteRequirements) sections.push(`Quote requirements:\n${quoteRequirements}`);
-  if (partSpecificNote) sections.push(`Part-specific note:\n${partSpecificNote}`);
+  const toBulletLines = (value: unknown) =>
+    String(value ?? '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean)
+      .map((line) => `- ${line}`);
+  const buildSection = (heading: string, value: unknown) => {
+    const items = toBulletLines(value);
+    if (!items.length) return '';
+    return `${heading}:\n${items.join('\n')}`;
+  };
+
+  const sections = [
+    buildSection('Quote requirements', quote?.requirements),
+    buildSection('Quote notes', quote?.notes),
+    buildSection('Materials', quote?.materialSummary),
+    buildSection('Purchase items', quote?.purchaseItems),
+    buildSection('Part-specific notes', part?.notes),
+  ].filter(Boolean);
   return sections.join('\n\n').trim();
 };
 

--- a/src/components/ShopFloorLayouts.tsx
+++ b/src/components/ShopFloorLayouts.tsx
@@ -415,7 +415,7 @@ export function ShopFloorLayouts({
             </div>
             <label className="flex items-center gap-2 text-xs text-muted-foreground">
               <Checkbox checked={includeCompleted} onCheckedChange={(value) => setIncludeCompleted(value === true)} />
-              Include completed work in this department
+              Show completed items
             </label>
           </div>
           <div className="flex flex-wrap gap-2">

--- a/src/components/work-queue/WorkQueueOrderCard.tsx
+++ b/src/components/work-queue/WorkQueueOrderCard.tsx
@@ -4,6 +4,15 @@ import { Badge } from '@/components/ui/badge';
 import { Card } from '@/components/ui/Card';
 import type { DepartmentFeedOrder } from '@/modules/orders/orders.types';
 
+function formatDuration(seconds: number) {
+  const clamped = Math.max(0, Math.floor(seconds));
+  const hours = Math.floor(clamped / 3600);
+  const minutes = Math.floor((clamped % 3600) / 60);
+  const secs = clamped % 60;
+  const pad = (value: number) => String(value).padStart(2, '0');
+  return `${pad(hours)}:${pad(minutes)}:${pad(secs)}`;
+}
+
 export function WorkQueueOrderCard({
   order,
   selectedDepartmentName,
@@ -37,6 +46,24 @@ export function WorkQueueOrderCard({
           <div>Due {order.dueDate ? new Date(order.dueDate).toLocaleDateString() : 'TBD'}</div>
           <div>{order.assignedMachinistName ?? 'Unassigned'}</div>
         </div>
+
+        {order.activeTimers.length ? (
+          <div className="flex flex-wrap gap-2">
+            {order.activeTimers.map((timer) => (
+              <span
+                key={timer.id}
+                className="inline-flex items-center rounded-full border border-emerald-500/30 bg-emerald-500/10 px-2 py-1 text-[11px] text-emerald-100"
+                title={
+                  timer.partNumber
+                    ? `${timer.userName} on ${timer.partNumber}${timer.departmentName ? ` in ${timer.departmentName}` : ''}`
+                    : `${timer.userName}${timer.departmentName ? ` in ${timer.departmentName}` : ''}`
+                }
+              >
+                {timer.userName}, {formatDuration(timer.elapsedSeconds)}
+              </span>
+            ))}
+          </div>
+        ) : null}
 
         <div className="grid grid-cols-2 gap-2 text-xs">
           <div className="rounded-lg border border-border/50 bg-muted/10 px-3 py-2">Parts here: {order.partsInDeptCount}</div>

--- a/src/modules/orders/orders.service.ts
+++ b/src/modules/orders/orders.service.ts
@@ -764,7 +764,7 @@ export async function getOrderDetails(
         const isComplete = part.status === 'COMPLETE';
         const fallbackDepartmentId =
           isComplete
-            ? null
+            ? part.currentDepartmentId ?? null
             : part.currentDepartmentId ?? departments[0]?.id ?? null;
         return {
           ...part,
@@ -1992,7 +1992,7 @@ export async function submitDepartmentComplete({
       return { currentDepartmentId: nextDepartmentId, status: 'IN_PROGRESS' as const };
     }
 
-    await updatePartCurrentDepartment(partId, null, tx);
+    await updatePartCurrentDepartment(partId, currentDepartmentId, tx);
     await recordPartEvent({
       orderId,
       partId,
@@ -2001,13 +2001,13 @@ export async function submitDepartmentComplete({
       message: 'All departments submitted complete. Part marked complete.',
       meta: {
         fromDepartmentId: currentDepartmentId,
-        toDepartmentId: null,
+        toDepartmentId: currentDepartmentId,
         transitionType: 'manual_submit',
         additionalSeconds: additionalSeconds ?? 0,
         adjustmentNote: adjustmentNote?.trim() || null,
       },
     }, tx);
-    return { currentDepartmentId: null, status: 'COMPLETE' as const };
+    return { currentDepartmentId, status: 'COMPLETE' as const };
   });
 
   await syncOrderWorkflowStatus(orderId, { userId: userId ?? null });
@@ -2050,7 +2050,7 @@ export async function completeOrderPart({
     return fail(409, 'Part can only be manually completed from Shipping.');
   }
 
-  const updated = await updateOrderPart(partId, { status: 'COMPLETE', currentDepartmentId: null });
+  const updated = await updateOrderPart(partId, { status: 'COMPLETE', currentDepartmentId });
 
   await recordPartEvent({
     orderId,
@@ -2170,11 +2170,16 @@ export async function getOrderDepartmentFeed(
 ): Promise<ServiceResult<{ items: DepartmentFeedOrder[] }>> {
   if (!departmentId) return fail(400, 'Department is required');
   const readyParts = await listReadyOrderPartsForDepartment(departmentId, includeCompleted);
+  const readyPartIds = readyParts.map((part: any) => part.id).filter(Boolean);
+  const partActivityById = readyPartIds.length
+    ? buildPartActivityByPart(readyPartIds, await listTimeEntriesForPartsDetailed(readyPartIds))
+    : {};
   const orders = new Map<string, DepartmentFeedOrder>();
 
   readyParts.forEach((part: any) => {
     const order = part.order;
     if (!order) return;
+    const partActivity = partActivityById[part.id] ?? { activeTimers: [], timeByUser: [], totalSeconds: 0 };
 
     const parsedEvents = (part.partEvents ?? []).map((event: any) => {
       if (typeof event.meta === 'string') {
@@ -2204,6 +2209,8 @@ export async function getOrderDepartmentFeed(
         openChecklistCount: 0,
         flaggedCount: 0,
         latestActivityAt: null,
+        activeTimerCount: 0,
+        activeTimers: [],
         parts: [],
       };
 
@@ -2221,6 +2228,23 @@ export async function getOrderDepartmentFeed(
     existing.partsInDeptCount += 1;
     existing.openChecklistCount += Math.max(checklistTotalCount - checklistDoneCount, 0);
     if (flaggedEvent) existing.flaggedCount += 1;
+    const activeTimers = Array.isArray(partActivity.activeTimers) ? partActivity.activeTimers : [];
+    activeTimers.forEach((timer: any) => {
+      existing.activeTimers.push({
+        id: String(timer?.id ?? `${part.id}-${timer?.userId ?? 'worker'}`),
+        userId: typeof timer?.userId === 'string' ? timer.userId : null,
+        userName: getUserLabel(timer?.user ?? null),
+        elapsedSeconds: Number(timer?.elapsedSeconds ?? 0),
+        departmentId: typeof timer?.departmentId === 'string' ? timer.departmentId : null,
+        departmentName:
+          typeof timer?.departmentName === 'string' && timer.departmentName.trim().length
+            ? timer.departmentName
+            : part.currentDepartment?.name ?? null,
+        partId: part.id,
+        partNumber: part.partNumber ?? null,
+      });
+      existing.activeTimerCount += 1;
+    });
 
     const eventAt = flaggedEvent?.createdAt ? new Date(flaggedEvent.createdAt) : null;
     if (eventAt && !Number.isNaN(eventAt.getTime())) {
@@ -2235,6 +2259,7 @@ export async function getOrderDepartmentFeed(
 
   const items = Array.from(orders.values())
     .sort((a, b) => {
+      if (a.activeTimerCount !== b.activeTimerCount) return b.activeTimerCount - a.activeTimerCount;
       if (a.flaggedCount !== b.flaggedCount) return b.flaggedCount - a.flaggedCount;
       const aDue = a.dueDate ? new Date(a.dueDate).getTime() : Number.POSITIVE_INFINITY;
       const bDue = b.dueDate ? new Date(b.dueDate).getTime() : Number.POSITIVE_INFINITY;
@@ -2243,6 +2268,12 @@ export async function getOrderDepartmentFeed(
     })
     .map((order) => ({
       ...order,
+      activeTimers: [...order.activeTimers]
+        .sort((a, b) => {
+          if (b.elapsedSeconds !== a.elapsedSeconds) return b.elapsedSeconds - a.elapsedSeconds;
+          return a.userName.localeCompare(b.userName, undefined, { sensitivity: 'base' });
+        })
+        .slice(0, 6),
       parts: [...order.parts].sort((a, b) => {
         if (a.flagged !== b.flagged) return a.flagged ? -1 : 1;
         return (a.partNumber ?? '').localeCompare((b.partNumber ?? ''), undefined, { numeric: true, sensitivity: 'base' });

--- a/src/modules/orders/orders.types.ts
+++ b/src/modules/orders/orders.types.ts
@@ -47,6 +47,17 @@ export type DepartmentFeedPart = {
   checklistTotalCount: number;
 };
 
+export type DepartmentFeedActiveTimer = {
+  id: string;
+  userId: string | null;
+  userName: string;
+  elapsedSeconds: number;
+  departmentId?: string | null;
+  departmentName?: string | null;
+  partId?: string | null;
+  partNumber?: string | null;
+};
+
 export type DepartmentFeedOrder = {
   orderId: string;
   orderNumber: string;
@@ -58,5 +69,7 @@ export type DepartmentFeedOrder = {
   openChecklistCount: number;
   flaggedCount: number;
   latestActivityAt: Date | string | null;
+  activeTimerCount: number;
+  activeTimers: DepartmentFeedActiveTimer[];
   parts: DepartmentFeedPart[];
 };

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -58,3 +58,14 @@ Record lessons after user corrections or process failures.
 ## 2026-02-23 — Tooling correction: patch workflow
 - When editing files, use the dedicated patch workflow/tool instead of invoking `apply_patch` through a generic shell execution command.
 - Before running patch operations, sanity-check that command/tool usage follows the repository interaction rules for this environment.
+## 2026-04-13 - Queue ownership and completion visibility must stay operator-visible
+- Trigger: User called out that active work should float to the top of department sorts, completed/shipped parts should not fall into an unassigned department state, and Vendors needed real pagination instead of endless load-more.
+- Mistake pattern: I left dashboard queue ordering too passive, let completion clear visible department ownership, and accepted a one-way list browsing pattern in admin where page navigation was expected.
+- Preventive rule: For floor queues, prioritize active work visually and preserve final ownership context for completed items; for admin tables that can grow, default to explicit pagination controls rather than assuming `Load more` is good enough.
+- Applied in next session where: 2026-04-13 queue priority + timer chips + Vendors pagination + completed department ownership.
+
+## 2026-04-13 - Timer/read-gate ownership must follow the selected worker, not the browser login
+- Trigger: User clarified that the required-reading popup was still effectively tied to the logged-in browser identity, which breaks shared-station timing when Bill starts work while Matt is logged in.
+- Mistake pattern: I reused the browser-session acknowledgement path for a worker-owned timer flow and only seeded a narrow subset of quote notes into the required-reading text.
+- Preventive rule: For shared-station timer flows, audit every read/acknowledgement step against the actual worker who will own the timer, and when quote content feeds required-reading text, include all original quote note-style fields in a structured, scannable format.
+- Applied in next session where: 2026-04-13 mission-brief worker PIN follow-up + quote-note bulletin formatting.

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,6 +1,161 @@
 ## Session Metadata
 - Date: 2026-04-13
 - Agent: Codex GPT-5
+- Task ID: Queue priority + timer chips + Vendors pagination + completed department ownership
+- Goal: Make department queue cards prioritize active work, show active timers on the tile, preserve department ownership for completed/shipped parts, and add real pagination to the Vendors page.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the follow-up gaps in code:
+  - department queue ordering did not prioritize active timers,
+  - work-queue tiles did not surface active timers,
+  - completed/shipped parts were clearing `currentDepartmentId` and reading as unassigned,
+  - Vendors used one-way `Load more` instead of explicit pagination.
+
+## Plan First
+- [x] Enrich department feed orders with active timer data and sort active-timer orders first.
+- [x] Surface active timer chips on department queue cards.
+- [x] Preserve final department ownership when parts reach `COMPLETE` so `Show completed items` can surface them.
+- [x] Convert Vendors to page-based pagination with total count and prev/next controls.
+- [x] Run focused verification and update continuity docs plus lessons.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/components/ShopFloorLayouts.tsx" "src/components/work-queue/WorkQueueOrderCard.tsx" "src/modules/orders/orders.service.ts" "src/modules/orders/orders.types.ts" "src/app/admin/vendors/client.tsx" "src/app/admin/vendors/page.tsx" "src/app/api/admin/vendors/route.ts"`
+
+## Review + Results
+- Department work queue cards now put active-timer orders first and show small green active timer chips on the order tile.
+- Completed and shipped parts now keep their final department ownership instead of dropping into an unassigned/null department state, which lets `Show completed items` surface them in the dashboard.
+- Vendors now uses explicit page-based navigation with total counts instead of a one-way load-more flow.
+
+## Session Metadata
+- Date: 2026-04-13
+- Agent: Codex GPT-5
+- Task ID: Mark Shipped button parity fix
+- Goal: Make `Mark Shipped` use the same real button layout as the other timer-row actions.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the follow-up UI gap in code:
+  - the shipping action label had been renamed,
+  - but the control was still a custom checkbox wrapper rather than a peer button, so it did not visually match `Start timer` and `Move Dept.`.
+
+## Plan First
+- [x] Replace the shipping control wrapper with the same button component pattern used by the neighboring actions.
+- [x] Preserve the Shipping-only enable/disable guard and click behavior.
+- [x] Run focused verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+## Review + Results
+- `Mark Shipped` now renders as a real outline button with the same sizing and layout pattern as the other timer-row actions.
+- The action keeps the same Shipping-only availability logic while looking visually consistent with the rest of the row.
+
+## Session Metadata
+- Date: 2026-04-13
+- Agent: Codex GPT-5
+- Task ID: Shipping action label + alignment polish
+- Goal: Rename the shipping completion control to `Mark Shipped` and align it visually with the rest of the timer action row.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current UI issue in code:
+  - the shipping action still used the longer `Complete in Shipping` label,
+  - its wrapper styling was visually less aligned with the neighboring action buttons.
+
+## Plan First
+- [x] Rename the shipping action label to `Mark Shipped`.
+- [x] Adjust the control wrapper to center and align visually with the rest of the timer row.
+- [x] Run focused verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+## Review + Results
+- The shipping-only completion action now reads `Mark Shipped`.
+- The wrapper styling now centers the checkbox/label content so the control sits more cleanly in line with the neighboring timer-row actions.
+
+## Session Metadata
+- Date: 2026-04-13
+- Agent: Codex GPT-5
+- Task ID: Active timer chip stop affordance
+- Goal: Add a stop icon to each active timer chip and remove the duplicate standalone stop button so chip-click is the clear stop path.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current UI state in code:
+  - active timer chips already open the worker-specific stop/PIN flow,
+  - the main action row still exposed a separate generic `Stop` button,
+  - that made the stop affordance feel duplicated and less worker-specific than the chip flow itself.
+
+## Plan First
+- [x] Add a small stop glyph to each active timer chip.
+- [x] Remove the main-row `Stop` button so the chip list is the single stop affordance.
+- [x] Run focused verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+## Review + Results
+- Active timer chips now display a stop icon at the end of the chip so the action reads more clearly.
+- The standalone `Stop` button was removed from the main timer row; stopping now happens by clicking the specific active timer chip for the worker you want to stop.
+
+## Session Metadata
+- Date: 2026-04-13
+- Agent: Codex GPT-5
+- Task ID: Live timer chips + instruction acknowledgement roster
+- Goal: Keep selected-part active timer chips ticking live on shared views and show who has already acknowledged the current Read Me First instruction version.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the follow-up issue in code:
+  - active timer chip elapsed labels were driven by a 1-second interval that only ran when `activeEntries.length > 0`,
+  - the chip list itself is driven by `selectedPartActivity.activeTimers`, so other-worker timers could freeze on screen,
+  - the `Read me first` panel already had receipt data available via `instructionReceipts` but did not surface the reader roster.
+
+## Plan First
+- [x] Move the live clock interval trigger to the selected part's active timer list.
+- [x] Add an acknowledgement roster for the current part/department/instruction version in the Read Me First panel.
+- [x] Run focused verification and update continuity docs.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
+
+## Review + Results
+- Active timer chips on `/orders/[id]` now tick live for the selected part even when the logged-in viewer does not personally have an active timer.
+- The Read Me First area now shows who has already acknowledged the current instruction version for the selected part's current department, along with acknowledgement timestamps.
+
+## Session Metadata
+- Date: 2026-04-13
+- Agent: Codex GPT-5
+- Task ID: Mission brief worker PIN follow-up + quote-note bulletin formatting
+- Goal: Make mission-brief acknowledgement follow the selected timer worker during timer start, and present quote-derived required-reading notes as headed bullet sections instead of a flat block.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the prior timer-tile follow-up behavior in code:
+  - timer start already used selected worker + PIN through the kiosk dialog,
+  - mission-brief acknowledgement still posted as the logged-in browser user,
+  - quote-to-order `workInstructions` still only carried a subset of quote note content and rendered as one flat text block on order detail.
+
+## Plan First
+- [x] Check required-reading status against the selected timer worker instead of only the current browser session user.
+- [x] Add worker selection + PIN confirmation to the timer-start mission-brief gate and route the acknowledgement through a verified selected-worker path.
+- [x] Reformat quote-derived `workInstructions` into headed bullet sections and render that structure in the order-detail brief UI.
+- [x] Run focused verification and update continuity docs plus lessons.
+
+## Verification Checklist
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx" "src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts"`
+
+## Review + Results
+- Timer start on `/orders/[id]` now opens the mission brief only when the selected worker still needs acknowledgement for the selected department, not just because the logged-in browser user has no receipt.
+- The timer-start mission-brief gate now lets the operator choose the worker and requires that worker's PIN before the acknowledgement is recorded for that worker.
+- The follow-up keeps checklist/submit acknowledgement behavior unchanged while making timer ownership and read receipts line up on shared floor stations.
+- Quote-derived required-reading text is now seeded from all original quote note-style fields and renders in order detail as heading + bullet sections for easier scanning.
+
+## Session Metadata
+- Date: 2026-04-13
+- Agent: Codex GPT-5
 - Task ID: Timer tile layout follow-up (dept + user + PIN flow)
 - Goal: Reshape the order-detail timer tile to match the requested department/user-first flow, fix the department dropdown reset bug, remove pause from the main tile, rename `Submit to` to `Move Dept.`, and restyle `Complete in Shipping` as a checkbox-style control.
 


### PR DESCRIPTION
## What changed
- polished the `/orders/[id]` timer area so worker-owned start/stop flows are clearer on shared stations
- updated the mission brief flow to support worker selection with PIN-backed acknowledgement and render quote-derived notes as headed bullet sections
- made active timer chips live on order detail, added acknowledgement rosters, and moved stop behavior onto the chips themselves
- refined the timer action row, including `Mark Shipped` button parity and repaired the order-detail layout regression so the part rail stays in the left sidebar
- updated the department work queue to sort active-timer orders first, show green worker/time timer chips on order tiles, and keep completed/shipped parts attached to their final department so `Show completed items` can surface them
- added page-based pagination to the Vendors admin list

## Why it changed
- shared floor stations need timer ownership and required-reading receipts to follow the actual worker, not whichever browser session happens to be open
- active work should be easier to spot and act on both inside order detail and on the dashboard queue
- completed/shipped work should remain visible under a meaningful department owner instead of falling into an unassigned state
- the Vendors list needed navigable pagination instead of one-way load-more behavior

## User impact
- workers can acknowledge required reading for the selected timer owner with that worker's PIN
- order-detail timer chips are clearer, live-updating, and act as the stop affordance
- department queue cards now surface active timers and prioritize hot work automatically
- completed/shipped items remain visible through the existing completed-items filter
- Vendors can be browsed page by page

## Validation
- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx"`
- `npx eslint --ext .ts,.tsx -- "src/components/ShopFloorLayouts.tsx" "src/components/work-queue/WorkQueueOrderCard.tsx" "src/modules/orders/orders.service.ts" "src/modules/orders/orders.types.ts" "src/app/admin/vendors/client.tsx" "src/app/admin/vendors/page.tsx" "src/app/api/admin/vendors/route.ts"`
- `npx eslint --ext .ts,.tsx -- "src/app/orders/[id]/page.tsx" "src/app/orders/new/page.tsx" "src/app/api/orders/[id]/parts/[partId]/acknowledge-instructions/route.ts"`