### PR TITLE
[codex] Add quote origin department and per-foot pricing

### DIFF
--- a/PROGRESS_LOG.md
+++ b/PROGRESS_LOG.md
@@ -1,3 +1,29 @@
+### 2026-04-14 - Quotes now support origin department, per-foot add-ons, and custom quote amounts
+- Updated quote workflow contracts and UI so admins can:
+  - assign an optional quote origin/default department,
+  - use `PER_FOOT` add-on pricing alongside `HOURLY` and `FLAT`,
+  - add titled custom quote amounts in review.
+- Updated shared pricing helpers and shared item components so rate/unit labeling now consistently reflects:
+  - hours for hourly,
+  - feet for per-foot,
+  - quantity for flat-rate items.
+- Updated quote persistence so origin department and custom amounts are stored in quote metadata, while the saved quote `totalCents` now matches the review estimate math including:
+  - part-pricing overrides,
+  - custom amounts.
+- Updated quote detail and quote print views to include custom-amount totals and clearer add-on unit labels.
+- Updated quote conversion so:
+  - converted order parts start in the quote origin department when one is set,
+  - custom quote amounts convert into non-checklist `CUSTOM` order charges using the origin/fallback department,
+  - existing add-on/checklist conversion behavior remains intact.
+
+Commands run:
+- `npx eslint --ext .ts,.tsx -- "src/app/admin/addons/client.tsx" "src/app/admin/addons/page.tsx" "src/app/admin/quotes/QuoteEditor.tsx" "src/app/admin/quotes/[id]/page.tsx" "src/app/admin/quotes/[id]/print/page.tsx" "src/app/orders/new/page.tsx" "src/components/AvailableItemsLibrary.tsx" "src/components/AssignedItemsPanel.tsx" "src/lib/zod.ts" "src/lib/quote-metadata.ts" "src/modules/pricing/work-item-pricing.ts" "src/modules/pricing/__tests__/work-item-pricing.test.ts" "src/modules/quotes/quotes.schema.ts" "src/modules/quotes/quotes.service.ts" "src/modules/quotes/quotes.repo.ts" "src/modules/quotes/quote-work-items.ts" "src/modules/quotes/__tests__/quote-work-items.test.ts" "src/modules/quotes/__tests__/quote-totals.test.ts" "src/app/api/admin/quotes/[id]/route.ts"`
+- `npm run test -- src/modules/pricing/__tests__/work-item-pricing.test.ts src/modules/quotes/__tests__/quote-work-items.test.ts src/modules/quotes/__tests__/quote-totals.test.ts`
+
+Verification note:
+- Targeted ESLint passed on all touched files.
+- Focused pricing/quote tests passed (`9/9`) after an outside-sandbox rerun because the sandboxed Vitest/esbuild startup hit Windows `spawn EPERM`.
+
 ### 2026-04-13 - Department queue now prioritizes active timers, shows timer chips, preserves completed department ownership, and Vendors has pagination
 - Updated `src/modules/orders/orders.service.ts` and `src/components/work-queue/WorkQueueOrderCard.tsx` so department work-queue cards now:
   - sort orders with active timers to the top before the existing flagged/due-date ordering,

--- a/docs/AGENT_CONTEXT.md
+++ b/docs/AGENT_CONTEXT.md
@@ -60,6 +60,10 @@ Goal: a scalable foundation that can grow.
 
 ## Decision Log (append newest at top)
 
+### 2026-04-14 - Quote origin department/custom amounts live in quote metadata; add-on rate types now include per-foot
+Decision: Extend quote workflow persistence by storing `originDepartmentId` and titled `customAmounts` in quote metadata, keep add-on/quote selection rate types string-based while adding `PER_FOOT`, and have quote conversion map custom amounts into non-checklist `CUSTOM` order charges using the quote origin department (or first active department fallback) while seeding converted parts to that same starting department.
+Reason: The owner needs quote-specific routing/pricing behavior without widening the Prisma quote schema unnecessarily, and the existing metadata + string snapshot contracts already provide a stable extension point. Mapping conversion through the saved origin department lets Paint-origin quotes start in Paint instead of defaulting to Machining, while custom amounts still satisfy the all-charges-are-per-part order model.
+
 ### 2026-04-13 - Completed parts keep their final department for queue visibility; department queue prioritizes active timers
 Decision: When a part reaches `COMPLETE`, preserve its final `currentDepartmentId` instead of clearing it to null, and have the department work queue sort orders with active timers ahead of the rest while showing order-level active timer chips on the card.
 Reason: Nulling the department makes completed/shipped work look unassigned and prevents the existing `Show completed items` filter from surfacing finished parts in the queue operators expect. Active timers are the hottest work on the floor, so they should rise to the top of department cards without changing the rest of the queue model.

--- a/docs/AGENT_HANDOFF.md
+++ b/docs/AGENT_HANDOFF.md
@@ -1,3 +1,79 @@
+## Session Handoff - 2026-04-14 (Quote origin department + per-foot pricing + custom quote amounts)
+
+Goal (1 sentence): Let admins route quotes from a non-default origin department, quote paint/add-on work by the foot, and add titled manual quote amounts that survive quote save, print, and quote-to-order conversion.
+
+### What changed
+- Updated shared pricing + add-on contracts:
+  - [work-item-pricing.ts](C:/Users/user/Documents/GitHub/shopapp1/src/modules/pricing/work-item-pricing.ts)
+  - [zod.ts](C:/Users/user/Documents/GitHub/shopapp1/src/lib/zod.ts)
+  - [AvailableItemsLibrary.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/components/AvailableItemsLibrary.tsx)
+  - [AssignedItemsPanel.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/components/AssignedItemsPanel.tsx)
+  - [client.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/addons/client.tsx)
+  - [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/addons/page.tsx)
+  - Add-ons now support `PER_FOOT` in addition to `HOURLY` and `FLAT`, and shared UI labels now render hours/feet/quantity consistently.
+- Updated quote metadata + totals handling:
+  - [quote-metadata.ts](C:/Users/user/Documents/GitHub/shopapp1/src/lib/quote-metadata.ts)
+  - [quotes.schema.ts](C:/Users/user/Documents/GitHub/shopapp1/src/modules/quotes/quotes.schema.ts)
+  - [quotes.service.ts](C:/Users/user/Documents/GitHub/shopapp1/src/modules/quotes/quotes.service.ts)
+  - [quotes.repo.ts](C:/Users/user/Documents/GitHub/shopapp1/src/modules/quotes/quotes.repo.ts)
+  - [route.ts](C:/Users/user/Documents/GitHub/shopapp1/src/app/api/admin/quotes/[id]/route.ts)
+  - Quotes now persist `originDepartmentId` and titled `customAmounts` in metadata, and the saved quote `totalCents` now matches the review estimate including part-pricing overrides and custom amounts.
+- Updated quote UI and print/detail surfaces:
+  - [QuoteEditor.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/quotes/QuoteEditor.tsx)
+  - [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/quotes/[id]/page.tsx)
+  - [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/admin/quotes/[id]/print/page.tsx)
+  - Quote review now includes:
+    - origin/default department selector,
+    - titled custom amount rows,
+    - summary totals that include custom amounts.
+  - Quote detail/print now show custom amount totals and updated add-on unit labels.
+- Updated quote conversion helpers:
+  - [quote-work-items.ts](C:/Users/user/Documents/GitHub/shopapp1/src/modules/quotes/quote-work-items.ts)
+  - [route.ts](C:/Users/user/Documents/GitHub/shopapp1/src/app/api/admin/quotes/[id]/convert/route.ts)
+  - Converted order parts now start in the quote origin department when set.
+  - Custom quote amounts now convert into non-checklist `CUSTOM` order charges on the first part using the origin/fallback department.
+- Compatibility touch-up:
+  - [page.tsx](C:/Users/user/Documents/GitHub/shopapp1/src/app/orders/new/page.tsx)
+  - Order-create’s shared add-on review display now understands `PER_FOOT` too, so the shared item components stay compile/runtime-safe.
+
+### Files touched
+- `src/modules/pricing/work-item-pricing.ts`
+- `src/modules/pricing/__tests__/work-item-pricing.test.ts`
+- `src/components/AvailableItemsLibrary.tsx`
+- `src/components/AssignedItemsPanel.tsx`
+- `src/lib/zod.ts`
+- `src/lib/quote-metadata.ts`
+- `src/modules/quotes/quotes.schema.ts`
+- `src/modules/quotes/quotes.service.ts`
+- `src/modules/quotes/quotes.repo.ts`
+- `src/modules/quotes/quote-work-items.ts`
+- `src/modules/quotes/__tests__/quote-work-items.test.ts`
+- `src/modules/quotes/__tests__/quote-totals.test.ts`
+- `src/app/admin/addons/client.tsx`
+- `src/app/admin/addons/page.tsx`
+- `src/app/admin/quotes/QuoteEditor.tsx`
+- `src/app/admin/quotes/[id]/page.tsx`
+- `src/app/admin/quotes/[id]/print/page.tsx`
+- `src/app/orders/new/page.tsx`
+- `src/app/api/admin/quotes/[id]/route.ts`
+- `tasks/todo.md`
+- `PROGRESS_LOG.md`
+- `docs/AGENT_HANDOFF.md`
+- `docs/AGENT_CONTEXT.md`
+
+### Commands run
+- `npx eslint --ext .ts,.tsx -- "src/app/admin/addons/client.tsx" "src/app/admin/addons/page.tsx" "src/app/admin/quotes/QuoteEditor.tsx" "src/app/admin/quotes/[id]/page.tsx" "src/app/admin/quotes/[id]/print/page.tsx" "src/app/orders/new/page.tsx" "src/components/AvailableItemsLibrary.tsx" "src/components/AssignedItemsPanel.tsx" "src/lib/zod.ts" "src/lib/quote-metadata.ts" "src/modules/pricing/work-item-pricing.ts" "src/modules/pricing/__tests__/work-item-pricing.test.ts" "src/modules/quotes/quotes.schema.ts" "src/modules/quotes/quotes.service.ts" "src/modules/quotes/quotes.repo.ts" "src/modules/quotes/quote-work-items.ts" "src/modules/quotes/__tests__/quote-work-items.test.ts" "src/modules/quotes/__tests__/quote-totals.test.ts" "src/app/api/admin/quotes/[id]/route.ts"`
+- `npm run test -- src/modules/pricing/__tests__/work-item-pricing.test.ts src/modules/quotes/__tests__/quote-work-items.test.ts src/modules/quotes/__tests__/quote-totals.test.ts`
+
+### Verification evidence
+- Targeted ESLint passed.
+- Focused quote/pricing tests passed (`9/9`) after an outside-sandbox rerun because the sandboxed Vitest/esbuild startup hit Windows `spawn EPERM`.
+
+### Behavior note for the next agent
+- Quote origin department is intentionally stored in metadata instead of a new `Quote` DB column; conversion resolves it against active departments and falls back to the first active department if the saved department is missing/inactive.
+- Custom quote amounts are quote-level UI rows, but the order domain still requires per-part charges, so conversion maps them onto the first converted part as `CUSTOM` charges using the origin/fallback department.
+- Existing quotes do not gain custom amounts or origin departments retroactively; they behave as before until saved with the new UI.
+
 ## Session Handoff - 2026-04-13 (Queue priority + timer chips + Vendors pagination + completed department ownership)
 
 Goal (1 sentence): Surface active work more clearly on the dashboard, preserve finished parts under a visible department owner, and give the Vendors page real pagination controls.

--- a/src/app/admin/addons/client.tsx
+++ b/src/app/admin/addons/client.tsx
@@ -21,6 +21,7 @@ import { fetchJson } from '@/lib/fetchJson';
 import { canAccessAdmin } from '@/lib/rbac';
 import { useCurrentUser } from '@/lib/use-current-user';
 import { AddonUpsert } from '@/lib/zod';
+import { formatWorkItemRateLabel, type WorkItemRateType } from '@/modules/pricing/work-item-pricing';
 
 interface Department {
   id: string;
@@ -33,7 +34,7 @@ interface Item {
   id: string;
   name: string;
   description?: string | null;
-  rateType: 'HOURLY' | 'FLAT';
+  rateType: WorkItemRateType;
   rateCents: number;
   active: boolean;
   affectsPrice: boolean;
@@ -48,12 +49,10 @@ interface ClientProps {
 
 type DialogState = { mode: 'create' | 'edit'; data?: Item } | null;
 
-const formatCurrency = (cents: number) =>
-  new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format((cents || 0) / 100);
-
 const RATE_LABEL: Record<Item['rateType'], string> = {
   HOURLY: 'Hourly',
   FLAT: 'Flat rate',
+  PER_FOOT: 'Per foot',
 };
 
 export default function Client({ initial }: ClientProps) {
@@ -119,8 +118,7 @@ export default function Client({ initial }: ClientProps) {
       {
         key: 'rateCents',
         header: 'Rate',
-        render: (_: number, row: Item) =>
-          `${formatCurrency(row.rateCents)}${row.rateType === 'HOURLY' ? ' / hr' : ''}`,
+        render: (_: number, row: Item) => formatWorkItemRateLabel(row),
       },
       {
         key: 'isChecklistItem',
@@ -263,7 +261,7 @@ export default function Client({ initial }: ClientProps) {
           <DialogHeader>
             <DialogTitle>{dialog?.mode === 'edit' ? 'Edit add-on' : 'New add-on'}</DialogTitle>
             <DialogDescription>
-              Hourly or fixed-rate services are available to admins while quoting and appear on order checklists.
+              Hourly, per-foot, or fixed-rate services are available to admins while quoting and appear on order checklists.
             </DialogDescription>
           </DialogHeader>
           <form
@@ -293,6 +291,7 @@ export default function Client({ initial }: ClientProps) {
                 className="rounded border border-border bg-background px-3 py-2 text-sm"
               >
                 <option value="HOURLY">Hourly</option>
+                <option value="PER_FOOT">Per foot</option>
                 <option value="FLAT">Flat rate</option>
               </select>
             </div>

--- a/src/app/admin/addons/page.tsx
+++ b/src/app/admin/addons/page.tsx
@@ -27,7 +27,7 @@ export default async function Page() {
       <NavTabs />
       <h1 className="text-xl font-semibold mb-3">Add-ons</h1>
       <p className="text-sm text-muted-foreground mb-6">
-        Configure hourly or flat-rate services that can be attached to quotes and orders. Rates are only visible to admins.
+        Configure hourly, per-foot, or flat-rate services that can be attached to quotes and orders. Rates are only visible to admins.
       </p>
       <ToastProvider>
         <Client initial={initial} />

--- a/src/app/admin/quotes/QuoteEditor.tsx
+++ b/src/app/admin/quotes/QuoteEditor.tsx
@@ -51,7 +51,10 @@ import {
   calculateAssignmentTotalCents,
   calculatePartPricingSummaryTotalsCents,
   calculateWorkItemsSubtotalCents,
+  formatWorkItemRateLabel,
+  getWorkItemUnitsLabel,
   getWorkItemPricingSemantic,
+  type WorkItemRateType,
 } from '@/modules/pricing/work-item-pricing';
 import { calculatePartLotTotal, calculatePartUnitPrice, type PartPricingMode } from '@/modules/pricing/part-pricing';
 import {
@@ -61,6 +64,7 @@ import {
   type QuoteAddonPreset,
   type QuoteAddonPresetItem,
 } from '@/modules/quotes/quote-addon-bulk';
+import { sumQuoteCustomAmountsCents, type QuoteCustomAmountEntry } from '@/lib/quote-metadata';
 
 import type { QuoteCreateInput } from '@/modules/quotes/quotes.schema';
 
@@ -78,13 +82,20 @@ type Option = {
 type AddonOption = {
   id: string;
   name: string;
-  rateType: 'HOURLY' | 'FLAT';
+  rateType: WorkItemRateType;
   rateCents: number;
   active: boolean;
   affectsPrice: boolean;
   isChecklistItem: boolean;
   description?: string | null;
   department?: { id: string; name: string } | null;
+};
+
+type DepartmentOption = {
+  id: string;
+  name: string;
+  isActive: boolean;
+  sortOrder: number;
 };
 
 type QuotePartState = {
@@ -117,6 +128,12 @@ type QuoteAddonState = {
   addonId: string;
   units: string;
   notes: string;
+};
+
+type QuoteCustomAmountState = {
+  key: string;
+  title: string;
+  amount: string;
 };
 
 const QUOTE_ADDON_PRESETS_STORAGE_KEY = 'quote-addon-presets-v1';
@@ -216,12 +233,14 @@ type QuoteDetail = {
     value: unknown;
   }>;
   metadata?: {
+    originDepartmentId?: string | null;
     partPricing?: Array<{
       name?: string | null;
       partNumber?: string | null;
       priceCents: number;
       pricingMode?: PartPricingMode;
     }>;
+    customAmounts?: QuoteCustomAmountEntry[];
   } | null;
 };
 
@@ -265,6 +284,7 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [addons, setAddons] = useState<AddonOption[]>([]);
+  const [departments, setDepartments] = useState<DepartmentOption[]>([]);
   const [vendors, setVendors] = useState<Option[]>([]);
   const [customers, setCustomers] = useState<Option[]>([]);
   const [materials, setMaterials] = useState<Option[]>([]);
@@ -428,6 +448,14 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
   const [selectedPresetId, setSelectedPresetId] = useState('');
   const [presetName, setPresetName] = useState('');
   const [copyTargetPartKey, setCopyTargetPartKey] = useState<'ALL' | string>('ALL');
+  const [originDepartmentId, setOriginDepartmentId] = useState(initialQuote?.metadata?.originDepartmentId ?? '');
+  const [customAmounts, setCustomAmounts] = useState<QuoteCustomAmountState[]>(
+    (initialQuote?.metadata?.customAmounts ?? []).map((entry, index) => ({
+      key: `${initialQuote?.id ?? 'quote'}-custom-${index}`,
+      title: entry.title ?? '',
+      amount: ((entry.amountCents ?? 0) / 100).toFixed(2),
+    }))
+  );
 
   const steps = [
     { key: 'info', label: 'Quote info' },
@@ -603,6 +631,11 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
       })
       .catch(() => setAddons([]));
 
+    fetch('/api/admin/departments', { credentials: 'include' })
+      .then((res) => (res.ok ? res.json() : Promise.reject(res)))
+      .then((data) => setDepartments(data.items ?? []))
+      .catch(() => setDepartments([]));
+
     fetch('/api/admin/vendors?take=100', { credentials: 'include' })
       .then((res) => (res.ok ? res.json() : Promise.reject(res)))
       .then((data) => {
@@ -710,6 +743,20 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
         notes: '',
       },
     ]);
+  }
+
+  function addCustomAmount() {
+    setCustomAmounts((prev) => [...prev, { key: createKey(), title: '', amount: '0.00' }]);
+  }
+
+  function updateCustomAmount(customAmountKey: string, patch: Partial<QuoteCustomAmountState>) {
+    setCustomAmounts((prev) =>
+      prev.map((item) => (item.key === customAmountKey ? { ...item, ...patch } : item))
+    );
+  }
+
+  function removeCustomAmount(customAmountKey: string) {
+    setCustomAmounts((prev) => prev.filter((item) => item.key !== customAmountKey));
   }
 
   function addAddonSelection(partKey: string, addonId = '') {
@@ -1012,6 +1059,21 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
     () => parts.find((part) => part.key === activePartKey) ?? parts[0],
     [activePartKey, parts]
   );
+  const selectedOriginDepartment = useMemo(
+    () => departments.find((department) => department.id === originDepartmentId) ?? null,
+    [departments, originDepartmentId]
+  );
+  const normalizedCustomAmounts = useMemo(
+    () =>
+      customAmounts
+        .map((item) => ({
+          key: item.key,
+          title: item.title.trim(),
+          amountCents: centsFromString(item.amount),
+        }))
+        .filter((item) => item.title.length > 0 || item.amountCents > 0),
+    [customAmounts]
+  );
 
   const vendorTotalsCents = vendorItems.reduce((sum, item) => {
     const base = centsFromString(item.basePrice);
@@ -1050,7 +1112,9 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
   });
   const addonsTotalsCents = pricingSummaryTotals.addonsAndLaborCents;
   const partPricingTotalCents = pricingSummaryTotals.partPricingCents;
-  const totalCents = basePriceCents + vendorTotalsCents + addonsTotalsCents + partPricingTotalCents;
+  const customAmountsTotalCents = sumQuoteCustomAmountsCents(normalizedCustomAmounts);
+  const totalCents =
+    basePriceCents + vendorTotalsCents + addonsTotalsCents + partPricingTotalCents + customAmountsTotalCents;
 
   const buildPayload = (): QuoteCreateInput => ({
     business: form.business,
@@ -1114,6 +1178,7 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
         })(),
         mimeType: attachment.mimeType || undefined,
       })),
+    originDepartmentId: originDepartmentId || undefined,
     partPricing: parts.map((part) => {
       const entry = partPricing.find((candidate) => candidate.partKey === part.key);
       const quantity = Number.parseInt(part.quantity || '1', 10) || 1;
@@ -1125,6 +1190,12 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
         pricingMode,
       };
     }),
+    customAmounts: normalizedCustomAmounts
+      .filter((item) => item.title.length > 0 && item.amountCents > 0)
+      .map((item) => ({
+        title: item.title,
+        amountCents: item.amountCents,
+      })),
     customFieldValues: customFields
       .map((field) => ({ fieldId: field.id, value: customFieldValues[field.id] }))
       .filter((entry) => hasCustomFieldValue(entry.value)),
@@ -1696,7 +1767,8 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
                         const totalCents = calculateAssignmentTotalCents({ item: addon, units });
                         return (
                           <div className="rounded border border-border/60 bg-background px-3 py-2 text-sm">
-                            {formatCurrency(addon.rateCents)} x {units.toFixed(2)} = {formatCurrency(totalCents)}
+                            {formatWorkItemRateLabel(addon)} x {units.toFixed(2)} {getWorkItemUnitsLabel(addon.rateType, 'short')} ={' '}
+                            {formatCurrency(totalCents)}
                           </div>
                         );
                       }}
@@ -2028,6 +2100,46 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
         <>
           <Card>
             <CardHeader>
+              <CardTitle>Quote routing</CardTitle>
+              <CardDescription>
+                Choose the department this quote should start from when it converts to an order.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="grid gap-4 md:grid-cols-[minmax(0,320px)_1fr] md:items-start">
+              <div className="grid gap-2">
+                <Label>Origin / default department</Label>
+                <Select value={originDepartmentId || '__auto__'} onValueChange={(value) => setOriginDepartmentId(value === '__auto__' ? '' : value)}>
+                  <SelectTrigger className="border border-border bg-background px-3 py-2 text-sm">
+                    <SelectValue placeholder="Use first active department" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="__auto__">Use first active department</SelectItem>
+                    {departments
+                      .filter((department) => department.isActive)
+                      .map((department) => (
+                        <SelectItem key={department.id} value={department.id}>
+                          {department.name}
+                        </SelectItem>
+                      ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="rounded border border-border/60 bg-background/60 p-3 text-sm text-muted-foreground">
+                {selectedOriginDepartment ? (
+                  <p>
+                    Converted orders from this quote will start in <span className="font-medium text-foreground">{selectedOriginDepartment.name}</span> unless a later workflow move changes them.
+                  </p>
+                ) : (
+                  <p>
+                    Leaving this blank keeps the current standard behavior: the order starts in the first active department.
+                  </p>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
               <CardTitle>Purchased items</CardTitle>
               <CardDescription>
                 Track vendor-sourced hardware or kits. Suggest markup percentages below to keep estimates consistent.
@@ -2276,6 +2388,52 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
 
           <Card>
             <CardHeader>
+              <CardTitle>Custom amounts</CardTitle>
+              <CardDescription>
+                Add manual one-off quote amounts with a title. These flow into the final estimate and convert into order charges using the quote origin department.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              {customAmounts.length ? (
+                customAmounts.map((item) => (
+                  <div key={item.key} className="grid gap-3 rounded border border-border/60 bg-background/60 p-3 md:grid-cols-[1.4fr_180px_auto] md:items-end">
+                    <div className="grid gap-2">
+                      <Label>Title</Label>
+                      <Input
+                        value={item.title}
+                        onChange={(event) => updateCustomAmount(item.key, { title: event.target.value })}
+                        placeholder="Rush setup"
+                      />
+                    </div>
+                    <div className="grid gap-2">
+                      <Label>Amount (USD)</Label>
+                      <Input
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={item.amount}
+                        onChange={(event) => updateCustomAmount(item.key, { amount: event.target.value })}
+                        placeholder="0.00"
+                      />
+                    </div>
+                    <Button type="button" variant="ghost" onClick={() => removeCustomAmount(item.key)}>
+                      Remove
+                    </Button>
+                  </div>
+                ))
+              ) : (
+                <div className="rounded border border-dashed border-border/60 bg-background/40 p-3 text-sm text-muted-foreground">
+                  No manual custom amounts added.
+                </div>
+              )}
+              <Button type="button" variant="outline" onClick={addCustomAmount}>
+                Add custom amount
+              </Button>
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
               <CardTitle>Summary</CardTitle>
               <CardDescription>Totals update automatically as you edit the quote.</CardDescription>
             </CardHeader>
@@ -2295,6 +2453,10 @@ export default function QuoteEditor({ mode, initialQuote }: QuoteEditorProps) {
               <div className="flex items-center justify-between text-sm">
                 <span>Part pricing (basis-adjusted)</span>
                 <span className="font-medium">{formatCurrency(partPricingTotalCents)}</span>
+              </div>
+              <div className="flex items-center justify-between text-sm">
+                <span>Custom amounts</span>
+                <span className="font-medium">{formatCurrency(customAmountsTotalCents)}</span>
               </div>
               <div className="border-t border-border/60 pt-3 text-sm font-semibold">
                 <div className="flex items-center justify-between">

--- a/src/app/admin/quotes/[id]/page.tsx
+++ b/src/app/admin/quotes/[id]/page.tsx
@@ -15,9 +15,13 @@ import {
 import AdminPricingGate from '@/components/Admin/AdminPricingGate';
 import { BUSINESS_OPTIONS, businessNameFromCode } from '@/lib/businesses';
 import { getPartPricingEntries } from '@/lib/quote-part-pricing';
-import { mergeQuoteMetadata } from '@/lib/quote-metadata';
+import { mergeQuoteMetadata, sumQuoteCustomAmountsCents } from '@/lib/quote-metadata';
 import { calculatePartLotTotal, calculatePartUnitPrice } from '@/modules/pricing/part-pricing';
-import { calculatePartPricingSummaryTotalsCents } from '@/modules/pricing/work-item-pricing';
+import {
+  calculatePartPricingSummaryTotalsCents,
+  formatWorkItemRateLabel,
+  getWorkItemUnitsLabel,
+} from '@/modules/pricing/work-item-pricing';
 import QuoteWorkflowControls from '../QuoteWorkflowControls';
 import QuoteQuickConvertDialog from '@/components/Admin/QuoteQuickConvertDialog';
 import { canAccessAdmin } from '@/lib/rbac';
@@ -135,8 +139,9 @@ export default async function QuoteDetailPage({ params }: { params: Promise<{ id
     pricingSummaryTotals.addonsAndLaborCents +
     legacyAddonSelections.reduce((sum, selection) => sum + selection.totalCents, 0);
   const partPricingTotal = pricingSummaryTotals.partPricingCents;
+  const customAmountsTotal = sumQuoteCustomAmountsCents(metadata.customAmounts);
   const partPricingByPartId = new Map(partPricingRows.map((row) => [row.part.id, row]));
-  const totalCents = quote.basePriceCents + addonTotal + vendorTotal + partPricingTotal;
+  const totalCents = quote.basePriceCents + addonTotal + vendorTotal + partPricingTotal + customAmountsTotal;
   const attachmentLinks = quote.attachments
     .map((attachment) => {
       if (attachment.url) {
@@ -337,6 +342,10 @@ export default async function QuoteDetailPage({ params }: { params: Promise<{ id
                     <span className="text-muted-foreground">Part pricing (basis-adjusted)</span>
                     <span className="font-medium">{formatCurrency(partPricingTotal)}</span>
                   </div>
+                  <div className="flex justify-between">
+                    <span className="text-muted-foreground">Custom amounts</span>
+                    <span className="font-medium">{formatCurrency(customAmountsTotal)}</span>
+                  </div>
                   <div className="border-t border-border/60 pt-2 flex justify-between text-base font-semibold">
                     <span>Total estimate</span>
                     <span className="text-primary">{formatCurrency(totalCents)}</span>
@@ -404,7 +413,24 @@ export default async function QuoteDetailPage({ params }: { params: Promise<{ id
               <p className="whitespace-pre-wrap text-muted-foreground">{quote.notes}</p>
             </div>
           )}
-          {!quote.materialSummary && !quote.purchaseItems && !quote.requirements && !quote.notes && (
+                  {metadata.customAmounts?.length ? (
+                    <div>
+                      <h3 className="font-medium mb-1">Custom amounts</h3>
+                      <div className="space-y-2">
+                        {metadata.customAmounts.map((entry) => (
+                          <div key={`${entry.title}-${entry.amountCents}`} className="flex items-center justify-between rounded border border-border/40 bg-card/30 px-3 py-2 text-xs">
+                            <span>{entry.title}</span>
+                            <span className="font-medium text-foreground">{formatCurrency(entry.amountCents)}</span>
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  ) : null}
+          {!quote.materialSummary &&
+            !quote.purchaseItems &&
+            !quote.requirements &&
+            !quote.notes &&
+            !(metadata.customAmounts?.length) && (
             <p className="text-muted-foreground">No additional notes recorded.</p>
           )}
         </CardContent>
@@ -466,11 +492,11 @@ export default async function QuoteDetailPage({ params }: { params: Promise<{ id
                           <div>
                             <p className="font-medium">{selection.addon?.name ?? 'Add-on removed'}</p>
                             <p className="text-xs text-muted-foreground">
-                              {selection.units} {selection.rateTypeSnapshot === 'FLAT' ? 'qty' : 'hrs'} •{' '}
+                              {selection.units} {getWorkItemUnitsLabel(selection.rateTypeSnapshot, 'short')} •{' '}
                               <AdminPricingGate
                                 initialRole={initialRole}
                                 initialAdmin={isAdmin}
-                                admin={isAdmin ? <span>Rate {formatCurrency(selection.rateCents)}</span> : null}
+                                admin={isAdmin ? <span>Rate {formatWorkItemRateLabel({ rateCents: selection.rateCents, rateType: selection.rateTypeSnapshot })}</span> : null}
                                 fallback={<span>Rate hidden</span>}
                               />
                             </p>
@@ -504,11 +530,11 @@ export default async function QuoteDetailPage({ params }: { params: Promise<{ id
                       <div>
                         <p className="font-medium">{selection.addon?.name ?? 'Add-on removed'}</p>
                         <p className="text-xs text-muted-foreground">
-                          {selection.units} {selection.rateTypeSnapshot === 'FLAT' ? 'qty' : 'hrs'} •{' '}
+                          {selection.units} {getWorkItemUnitsLabel(selection.rateTypeSnapshot, 'short')} •{' '}
                           <AdminPricingGate
                             initialRole={initialRole}
                             initialAdmin={isAdmin}
-                            admin={isAdmin ? <span>Rate {formatCurrency(selection.rateCents)}</span> : null}
+                            admin={isAdmin ? <span>Rate {formatWorkItemRateLabel({ rateCents: selection.rateCents, rateType: selection.rateTypeSnapshot })}</span> : null}
                             fallback={<span>Rate hidden</span>}
                           />
                         </p>

--- a/src/app/admin/quotes/[id]/print/page.tsx
+++ b/src/app/admin/quotes/[id]/print/page.tsx
@@ -6,9 +6,12 @@ import { getServerAuthSession } from '@/lib/auth-session';
 import { canAccessAdmin } from '@/lib/rbac';
 import { normalizeTemplateLayout } from '@/lib/document-template-layout';
 import { getPartPricingEntries } from '@/lib/quote-part-pricing';
-import { mergeQuoteMetadata, parseQuoteMetadata } from '@/lib/quote-metadata';
+import { mergeQuoteMetadata, parseQuoteMetadata, sumQuoteCustomAmountsCents } from '@/lib/quote-metadata';
 import { calculatePartLotTotal, calculatePartUnitPrice } from '@/modules/pricing/part-pricing';
-import { calculatePartPricingSummaryTotalsCents } from '@/modules/pricing/work-item-pricing';
+import {
+  calculatePartPricingSummaryTotalsCents,
+  getWorkItemUnitsLabel,
+} from '@/modules/pricing/work-item-pricing';
 import {
   buildQuoteRenderBlocks,
   DEFAULT_QUOTE_ADDONS_OPTIONS,
@@ -121,7 +124,8 @@ export default async function QuotePrintPage({
     pricingSummaryTotals.addonsAndLaborCents +
     legacyAddonSelections.reduce((sum, selection) => sum + selection.totalCents, 0);
   const partPricingTotal = pricingSummaryTotals.partPricingCents;
-  const total = quote.basePriceCents + addonTotal + vendorTotal + partPricingTotal;
+  const customAmountsTotal = sumQuoteCustomAmountsCents(metadata.customAmounts);
+  const total = quote.basePriceCents + addonTotal + vendorTotal + partPricingTotal + customAmountsTotal;
   const addonSelections = quote.addonSelections.filter((selection) => selection.addon);
   const hasAddons = addonSelections.length > 0;
   const hasVendorItems = quote.vendorItems.length > 0;
@@ -174,6 +178,10 @@ export default async function QuotePrintPage({
         <div>
           <p className="text-xs uppercase text-neutral-500">Part pricing</p>
           <p className="font-semibold">{formatCurrency(partPricingTotal)}</p>
+        </div>
+        <div>
+          <p className="text-xs uppercase text-neutral-500">Custom amounts</p>
+          <p className="font-semibold">{formatCurrency(customAmountsTotal)}</p>
         </div>
         <div className="col-span-2 border-t border-black pt-2 text-right text-base font-semibold">
           Total: {formatCurrency(total)}
@@ -309,6 +317,7 @@ export default async function QuotePrintPage({
     const showPartContext = addonsOptions.showPartContext === true;
     const showVendorItems = addonsOptions.showVendorItems !== false;
     const hasVisibleVendorItems = showVendorItems && hasVendorItems;
+    const customAmounts = metadata.customAmounts ?? [];
 
     return (
       <section className="border border-black">
@@ -331,7 +340,11 @@ export default async function QuotePrintPage({
                           {selection.partNumber ? ` (${selection.partNumber})` : ''}
                         </div>
                       ) : null}
-                      {showUnits ? <div className={`${metaClass} text-neutral-500`}>Units: {selection.units}</div> : null}
+                      {showUnits ? (
+                        <div className={`${metaClass} text-neutral-500`}>
+                          {getWorkItemUnitsLabel(selection.rateTypeSnapshot)}: {selection.units}
+                        </div>
+                      ) : null}
                       {showNotes && selection.notes ? <div className={`${metaClass} whitespace-pre-wrap text-neutral-500`}>{selection.notes}</div> : null}
                     </div>
                     {showPrices ? <span className="font-semibold">{formatCurrency(selection.totalCents)}</span> : null}
@@ -352,6 +365,19 @@ export default async function QuotePrintPage({
                       {showNotes && item.notes ? <div className={`${metaClass} whitespace-pre-wrap text-neutral-500`}>{item.notes}</div> : null}
                     </div>
                     {showPrices ? <span className="font-semibold">{formatCurrency(item.finalPriceCents)}</span> : null}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {customAmounts.length > 0 && (
+            <div className={hasAddons || hasVisibleVendorItems ? 'mt-3' : ''}>
+              <p className={`${metaClass} uppercase text-neutral-500`}>Custom amounts</p>
+              <ul className="mt-1 space-y-1">
+                {customAmounts.map((entry) => (
+                  <li key={`${entry.title}-${entry.amountCents}`} className="flex items-start justify-between gap-4">
+                    <div>{entry.title}</div>
+                    {showPrices ? <span className="font-semibold">{formatCurrency(entry.amountCents)}</span> : null}
                   </li>
                 ))}
               </ul>

--- a/src/app/api/admin/quotes/[id]/route.ts
+++ b/src/app/api/admin/quotes/[id]/route.ts
@@ -97,17 +97,24 @@ export async function PATCH(req: NextRequest, { params }: { params: Promise<{ id
   }
 
   const existingMetadata = parseQuoteMetadata(existing.metadata) ?? DEFAULT_QUOTE_METADATA;
-  const nextMetadata = parsed.data.partPricing
-    ? {
-        ...existingMetadata,
-        partPricing: parsed.data.partPricing.map((entry) => ({
+  const nextMetadata = {
+    ...existingMetadata,
+    originDepartmentId: parsed.data.originDepartmentId ?? null,
+    partPricing: parsed.data.partPricing
+      ? parsed.data.partPricing.map((entry) => ({
           name: entry.name ?? null,
           partNumber: entry.partNumber ?? null,
           priceCents: entry.priceCents ?? 0,
           pricingMode: entry.pricingMode === 'PER_UNIT' ? 'PER_UNIT' : 'LOT_TOTAL',
-        })),
-      }
-    : existingMetadata;
+        }))
+      : existingMetadata.partPricing,
+    customAmounts: parsed.data.customAmounts
+      ? parsed.data.customAmounts.map((entry) => ({
+          title: entry.title,
+          amountCents: entry.amountCents ?? 0,
+        }))
+      : existingMetadata.customAmounts,
+  };
 
   const customFieldValues = parsed.data.customFieldValues ?? [];
   const validCustomFieldValues = customFieldValues.length

--- a/src/app/orders/new/page.tsx
+++ b/src/app/orders/new/page.tsx
@@ -47,7 +47,10 @@ import { hasCustomFieldValue } from '@/lib/custom-field-values';
 import {
   calculateAssignmentTotalCents,
   calculateWorkItemsSubtotalCents,
+  formatWorkItemRateLabel,
+  getWorkItemUnitsLabel,
   getWorkItemPricingSemantic,
+  type WorkItemRateType,
 } from '@/modules/pricing/work-item-pricing';
 import { calculatePartLotTotal, type PartPricingMode } from '@/modules/pricing/part-pricing';
 import type { RepeatOrderTemplateDetail } from '@/modules/repeat-orders/repeat-orders.types';
@@ -71,7 +74,7 @@ type AddonOption = {
   id: string;
   name: string;
   description?: string | null;
-  rateType?: 'HOURLY' | 'FLAT';
+  rateType?: WorkItemRateType;
   rateCents?: number;
   active?: boolean;
   affectsPrice?: boolean;
@@ -1659,7 +1662,8 @@ function NewOrderForm() {
                           const totalCents = calculateAssignmentTotalCents({ item, units });
                           return (
                             <div className="rounded border border-border/60 bg-background px-3 py-2 text-sm">
-                              {formatCurrency(item.rateCents)} x {units.toFixed(2)} = {formatCurrency(totalCents)}
+                              {formatWorkItemRateLabel(item)} x {units.toFixed(2)} {getWorkItemUnitsLabel(item.rateType, 'short')} ={' '}
+                              {formatCurrency(totalCents)}
                             </div>
                           );
                         }}

--- a/src/components/AssignedItemsPanel.tsx
+++ b/src/components/AssignedItemsPanel.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
 import { Textarea } from '@/components/ui/Textarea';
 import type { AvailableItem } from '@/components/AvailableItemsLibrary';
+import { getWorkItemUnitsLabel } from '@/modules/pricing/work-item-pricing';
 
 export type AssignedItem = {
   key: string;
@@ -37,12 +38,6 @@ const parseDroppedItem = (event: React.DragEvent<HTMLDivElement>) => {
     return null;
   }
   return null;
-};
-
-const getUnitsLabel = (item?: AvailableItem) => {
-  if (item?.rateType === 'HOURLY') return 'Hours';
-  if (item?.rateType === 'FLAT') return 'Quantity';
-  return 'Units';
 };
 
 export function AssignedItemsPanel({
@@ -132,7 +127,9 @@ export function AssignedItemsPanel({
                 </div>
                 <div className="mt-3 grid gap-3 md:grid-cols-3">
                   <div className="grid gap-2">
-                    <label className="text-xs font-medium text-muted-foreground">{getUnitsLabel(item)}</label>
+                    <label className="text-xs font-medium text-muted-foreground">
+                      {getWorkItemUnitsLabel(item?.rateType)}
+                    </label>
                     <Input
                       type="number"
                       min="0"

--- a/src/components/AvailableItemsLibrary.tsx
+++ b/src/components/AvailableItemsLibrary.tsx
@@ -5,12 +5,13 @@ import React from 'react';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/Button';
 import { Input } from '@/components/ui/Input';
+import { formatWorkItemRateLabel, type WorkItemRateType } from '@/modules/pricing/work-item-pricing';
 
 export type AvailableItem = {
   id: string;
   name: string;
   description?: string | null;
-  rateType?: 'HOURLY' | 'FLAT';
+  rateType?: WorkItemRateType;
   rateCents?: number;
   departmentName?: string | null;
   affectsPrice: boolean;
@@ -24,13 +25,6 @@ type AvailableItemsLibraryProps = {
   onAddItem: (item: AvailableItem) => void;
   disabled?: boolean;
 };
-
-function formatRate(item: AvailableItem) {
-  if (typeof item.rateCents !== 'number') return null;
-  const amount = item.rateCents / 100;
-  const formatted = amount.toLocaleString(undefined, { style: 'currency', currency: 'USD' });
-  return item.rateType === 'HOURLY' ? `${formatted}/hr` : formatted;
-}
 
 function groupItems(items: AvailableItem[]) {
   const grouped = new Map<string, AvailableItem[]>();
@@ -116,12 +110,18 @@ export function AvailableItemsLibrary({
                       )}
                       {item.rateType ? (
                         <Badge variant="secondary" className="text-[10px] uppercase">
-                          {item.rateType === 'HOURLY' ? 'Labor' : 'Flat'}
+                          {item.rateType === 'HOURLY'
+                            ? 'Labor'
+                            : item.rateType === 'PER_FOOT'
+                              ? 'Per foot'
+                              : 'Flat'}
                         </Badge>
                       ) : null}
                     </div>
                     {item.affectsPrice && typeof item.rateCents === 'number' ? (
-                      <div className="text-xs font-medium text-foreground">{formatRate(item)}</div>
+                      <div className="text-xs font-medium text-foreground">
+                        {formatWorkItemRateLabel(item)}
+                      </div>
                     ) : null}
                   </div>
                   <Button

--- a/src/lib/quote-metadata.ts
+++ b/src/lib/quote-metadata.ts
@@ -20,11 +20,18 @@ export type QuotePartPricingEntry = {
   pricingMode?: 'PER_UNIT' | 'LOT_TOTAL';
 };
 
+export type QuoteCustomAmountEntry = {
+  title: string;
+  amountCents: number;
+};
+
 export type QuoteMetadata = Record<string, unknown> & {
   markupSuggestions?: number[];
   approval?: QuoteApprovalMetadata;
   conversion?: QuoteConversionMetadata;
   partPricing?: QuotePartPricingEntry[];
+  originDepartmentId?: string | null;
+  customAmounts?: QuoteCustomAmountEntry[];
 };
 
 const DEFAULT_APPROVAL: QuoteApprovalMetadata = {
@@ -61,6 +68,20 @@ function clonePartPricing(values: QuotePartPricingEntry[] | undefined): QuotePar
   }));
 }
 
+function cloneCustomAmounts(values: QuoteCustomAmountEntry[] | undefined): QuoteCustomAmountEntry[] | undefined {
+  if (!values) return undefined;
+  return values
+    .map((entry) => ({
+      title: String(entry.title ?? '').trim(),
+      amountCents: Math.max(0, Math.round(Number(entry.amountCents ?? 0) || 0)),
+    }))
+    .filter((entry) => entry.title.length > 0 && entry.amountCents > 0);
+}
+
+export function sumQuoteCustomAmountsCents(values: QuoteCustomAmountEntry[] | undefined): number {
+  return (values ?? []).reduce((sum, entry) => sum + Math.max(0, Number(entry.amountCents ?? 0) || 0), 0);
+}
+
 export function mergeQuoteMetadata(metadata: QuoteMetadata | null | undefined): QuoteMetadata {
   const base = metadata && typeof metadata === 'object' ? metadata : {};
   const approval =
@@ -80,6 +101,11 @@ export function mergeQuoteMetadata(metadata: QuoteMetadata | null | undefined): 
     approval,
     conversion,
     partPricing: Array.isArray(base.partPricing) ? clonePartPricing(base.partPricing) : undefined,
+    originDepartmentId:
+      typeof base.originDepartmentId === 'string' && base.originDepartmentId.trim().length > 0
+        ? base.originDepartmentId
+        : null,
+    customAmounts: Array.isArray(base.customAmounts) ? cloneCustomAmounts(base.customAmounts) : undefined,
   } satisfies QuoteMetadata;
 }
 

--- a/src/lib/zod.ts
+++ b/src/lib/zod.ts
@@ -56,7 +56,7 @@ export const VendorUpsert = z.object({
 export const VendorPatch = VendorUpsert.partial();
 
 /** ADDONS */
-export const AddonRateType = z.enum(['HOURLY', 'FLAT']);
+export const AddonRateType = z.enum(['HOURLY', 'FLAT', 'PER_FOOT']);
 export const AddonUpsert = z.object({
   name: z.string().trim().min(2).max(120),
   description: z.string().trim().max(1000).optional(),

--- a/src/modules/pricing/__tests__/work-item-pricing.test.ts
+++ b/src/modules/pricing/__tests__/work-item-pricing.test.ts
@@ -3,7 +3,10 @@ import {
   calculateAssignmentTotalCents,
   calculatePartPricingSummaryTotalsCents,
   calculateWorkItemsSubtotalCents,
+  formatWorkItemRateLabel,
+  getWorkItemUnitsLabel,
   getWorkItemPricingSemantic,
+  normalizeWorkItemRateType,
 } from '@/modules/pricing/work-item-pricing';
 
 describe('work-item-pricing', () => {
@@ -30,6 +33,13 @@ describe('work-item-pricing', () => {
     });
 
     expect(subtotal).toBe(2000);
+  });
+
+  it('supports per-foot rate labels and unit labels', () => {
+    expect(normalizeWorkItemRateType('PER_FOOT')).toBe('PER_FOOT');
+    expect(getWorkItemUnitsLabel('PER_FOOT')).toBe('Feet');
+    expect(getWorkItemUnitsLabel('PER_FOOT', 'short')).toBe('ft');
+    expect(formatWorkItemRateLabel({ rateCents: 425, rateType: 'PER_FOOT' })).toBe('$4.25/ft');
   });
 
   it('replaces raw work-item subtotal with basis-adjusted part pricing when override is present', () => {

--- a/src/modules/pricing/work-item-pricing.ts
+++ b/src/modules/pricing/work-item-pricing.ts
@@ -1,10 +1,43 @@
 export type WorkItemPricingInput = {
+  rateType?: string | null;
   rateCents?: number | null;
   affectsPrice?: boolean | null;
   isChecklistItem?: boolean | null;
 };
 
 export type WorkItemPricingSemantic = 'PRICED_WORK' | 'CHECKLIST_ONLY';
+export type WorkItemRateType = 'HOURLY' | 'FLAT' | 'PER_FOOT';
+
+export const normalizeWorkItemRateType = (rateType?: string | null): WorkItemRateType => {
+  if (rateType === 'FLAT') return 'FLAT';
+  if (rateType === 'PER_FOOT') return 'PER_FOOT';
+  return 'HOURLY';
+};
+
+export const getWorkItemUnitsLabel = (
+  rateType?: string | null,
+  variant: 'long' | 'short' = 'long'
+) => {
+  const normalized = normalizeWorkItemRateType(rateType);
+  if (normalized === 'HOURLY') return variant === 'short' ? 'hrs' : 'Hours';
+  if (normalized === 'PER_FOOT') return variant === 'short' ? 'ft' : 'Feet';
+  return variant === 'short' ? 'qty' : 'Quantity';
+};
+
+export const formatWorkItemRateLabel = ({
+  rateCents,
+  rateType,
+}: {
+  rateCents?: number | null;
+  rateType?: string | null;
+}) => {
+  if (typeof rateCents !== 'number') return null;
+  const formatted = new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(rateCents / 100);
+  const normalized = normalizeWorkItemRateType(rateType);
+  if (normalized === 'HOURLY') return `${formatted}/hr`;
+  if (normalized === 'PER_FOOT') return `${formatted}/ft`;
+  return formatted;
+};
 
 export const getWorkItemPricingSemantic = (item: WorkItemPricingInput): WorkItemPricingSemantic => {
   if (item.affectsPrice === false) return 'CHECKLIST_ONLY';

--- a/src/modules/quotes/__tests__/quote-totals.test.ts
+++ b/src/modules/quotes/__tests__/quote-totals.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { calculatePricedAddonTotal } from '../quotes.service';
+import { calculatePricedAddonTotal, calculateQuoteEstimateTotalCents } from '../quotes.service';
 
 describe('calculatePricedAddonTotal', () => {
   it('ignores checklist-only items when totaling price', () => {
@@ -10,5 +10,37 @@ describe('calculatePricedAddonTotal', () => {
     ]);
 
     expect(total).toBe(3000);
+  });
+
+  it('includes custom amounts and part-pricing overrides in the saved estimate total', () => {
+    const total = calculateQuoteEstimateTotalCents({
+      basePriceCents: 10000,
+      vendorTotalCents: 2500,
+      customAmountsCents: 1800,
+      addonMap: new Map([
+        ['paint', { rateCents: 400, affectsPrice: true }],
+        ['check', { rateCents: 150, affectsPrice: false }],
+      ]),
+      parts: [
+        {
+          name: 'Rail',
+          quantity: 10,
+          pieceCount: 1,
+          addonSelections: [
+            { addonId: 'paint', units: 12 },
+            { addonId: 'check', units: 4 },
+          ],
+        },
+      ],
+      partPricing: [
+        {
+          name: 'Rail',
+          priceCents: 900,
+          pricingMode: 'PER_UNIT',
+        },
+      ],
+    });
+
+    expect(total).toBe(10000 + 2500 + 9000 + 1800);
   });
 });

--- a/src/modules/quotes/__tests__/quote-work-items.test.ts
+++ b/src/modules/quotes/__tests__/quote-work-items.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildChecklistEntriesFromQuoteSelections } from '../quote-work-items';
+import {
+  buildChecklistEntriesFromQuoteSelections,
+  buildOrderChargeEntriesFromQuoteData,
+} from '../quote-work-items';
 
 describe('buildChecklistEntriesFromQuoteSelections', () => {
   it('creates per-part checklist entries from quote selections', () => {
@@ -45,6 +48,58 @@ describe('buildChecklistEntriesFromQuoteSelections', () => {
         departmentId: 'dept-1',
         completed: false,
         isActive: true,
+      },
+    ]);
+  });
+
+  it('builds priced order charges and falls back custom amounts to the origin department', () => {
+    const charges = buildOrderChargeEntriesFromQuoteData({
+      orderId: 'order-1',
+      selections: [
+        {
+          orderPartId: 'part-1',
+          selection: {
+            addonId: 'addon-1',
+            units: 12,
+            notes: 'Paint both sides',
+            addon: {
+              name: 'Wet Paint',
+              departmentId: 'paint',
+              affectsPrice: true,
+              rateCents: 450,
+            },
+          },
+        },
+      ],
+      customAmounts: [{ title: 'Rush paint setup', amountCents: 17500 }],
+      customAmountPartId: 'part-1',
+      fallbackDepartmentId: 'paint',
+    });
+
+    expect(charges).toEqual([
+      {
+        orderId: 'order-1',
+        partId: 'part-1',
+        departmentId: 'paint',
+        addonId: 'addon-1',
+        kind: 'ADDON',
+        name: 'Wet Paint',
+        description: 'Paint both sides',
+        quantity: 12,
+        unitPriceCents: 450,
+        sortOrder: 0,
+      },
+      {
+        orderId: 'order-1',
+        partId: 'part-1',
+        departmentId: 'paint',
+        addonId: null,
+        kind: 'CUSTOM',
+        name: 'Rush paint setup',
+        description: null,
+        quantity: 1,
+        unitPriceCents: 17500,
+        sortOrder: 1,
       },
     ]);
   });

--- a/src/modules/quotes/quote-work-items.ts
+++ b/src/modules/quotes/quote-work-items.ts
@@ -42,3 +42,91 @@ export function buildChecklistEntriesFromQuoteSelections(
 
   return entries;
 }
+
+export type QuoteChargeSelection = {
+  orderPartId: string | null;
+  selection: {
+    addonId?: string | null;
+    units?: number | null;
+    notes?: string | null;
+    addon?: {
+      name?: string | null;
+      departmentId?: string | null;
+      affectsPrice?: boolean | null;
+      rateCents?: number | null;
+    } | null;
+  };
+};
+
+export type CustomQuoteAmountInput = {
+  title: string;
+  amountCents: number;
+};
+
+export type QuoteOrderChargeInput = {
+  orderId: string;
+  partId: string;
+  departmentId: string;
+  addonId: string | null;
+  kind: string;
+  name: string;
+  description: string | null;
+  quantity: number;
+  unitPriceCents: number;
+  sortOrder: number;
+};
+
+export function buildOrderChargeEntriesFromQuoteData({
+  orderId,
+  selections,
+  customAmounts,
+  customAmountPartId,
+  fallbackDepartmentId,
+}: {
+  orderId: string;
+  selections: QuoteChargeSelection[];
+  customAmounts?: CustomQuoteAmountInput[];
+  customAmountPartId?: string | null;
+  fallbackDepartmentId?: string | null;
+}): QuoteOrderChargeInput[] {
+  const charges: QuoteOrderChargeInput[] = [];
+
+  for (const entry of selections) {
+    const partId = entry.orderPartId;
+    const addon = entry.selection.addon;
+    if (!partId || addon?.affectsPrice === false) continue;
+    const departmentId = addon?.departmentId ?? fallbackDepartmentId ?? null;
+    if (!departmentId) continue;
+    charges.push({
+      orderId,
+      partId,
+      departmentId,
+      addonId: entry.selection.addonId ?? null,
+      kind: 'ADDON',
+      name: addon?.name ?? 'Add-on',
+      description: entry.selection.notes ?? null,
+      quantity: Number(entry.selection.units ?? 0) || 0,
+      unitPriceCents: Number(addon?.rateCents ?? 0) || 0,
+      sortOrder: charges.length,
+    });
+  }
+
+  for (const customAmount of customAmounts ?? []) {
+    const title = customAmount.title.trim();
+    if (!title || customAmount.amountCents <= 0 || !customAmountPartId || !fallbackDepartmentId) continue;
+    charges.push({
+      orderId,
+      partId: customAmountPartId,
+      departmentId: fallbackDepartmentId,
+      addonId: null,
+      kind: 'CUSTOM',
+      name: title,
+      description: null,
+      quantity: 1,
+      unitPriceCents: customAmount.amountCents,
+      sortOrder: charges.length,
+    });
+  }
+
+  return charges;
+}

--- a/src/modules/quotes/quotes.repo.ts
+++ b/src/modules/quotes/quotes.repo.ts
@@ -12,6 +12,7 @@ import {
   type QuoteApprovalMetadata,
 } from '@/lib/quote-metadata';
 import { buildChecklistEntriesFromQuoteSelections } from './quote-work-items';
+import { buildOrderChargeEntriesFromQuoteData } from './quote-work-items';
 
 export async function listQuotes({
   where,
@@ -112,11 +113,16 @@ export async function createQuoteWithDetails({
         totalCents: prepared.totalCents,
         metadata: stringifyQuoteMetadata({
           ...DEFAULT_QUOTE_METADATA,
+          originDepartmentId: data.originDepartmentId ?? null,
           partPricing: data.partPricing?.map((entry: any) => ({
             name: entry.name ?? null,
             partNumber: entry.partNumber ?? null,
             priceCents: entry.priceCents ?? 0,
             pricingMode: entry.pricingMode === 'PER_UNIT' ? 'PER_UNIT' : 'LOT_TOTAL',
+          })),
+          customAmounts: data.customAmounts?.map((entry: any) => ({
+            title: entry.title?.trim() ?? '',
+            amountCents: entry.amountCents ?? 0,
           })),
         }),
         createdById: userId,
@@ -601,6 +607,19 @@ async function generateNextOrderNumberInTx(tx: any, business: BusinessCode) {
   return `${prefix}-${maxValue + 1}`;
 }
 
+async function resolveQuoteOriginDepartmentId(tx: any, preferredDepartmentId: string | null | undefined) {
+  const departments = await tx.department.findMany({
+    where: { isActive: true },
+    orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
+    select: { id: true },
+  });
+  if (!departments.length) return null;
+  if (preferredDepartmentId && departments.some((department: { id: string }) => department.id === preferredDepartmentId)) {
+    return preferredDepartmentId;
+  }
+  return departments[0]?.id ?? null;
+}
+
 export async function convertQuoteToOrder({
   quote,
   metadata,
@@ -650,6 +669,10 @@ export async function convertQuoteToOrder({
 }) {
   return prisma.$transaction(async (tx) => {
     const orderNumber = await generateNextOrderNumberInTx(tx, quote.business as BusinessCode);
+    const originDepartmentId = await resolveQuoteOriginDepartmentId(
+      tx,
+      typeof metadata?.originDepartmentId === 'string' ? metadata.originDepartmentId : null
+    );
 
     const order = await tx.order.create({
       data: {
@@ -688,6 +711,7 @@ export async function convertQuoteToOrder({
             partNumber: part.partNumber,
             quantity: part.quantity,
             materialId: part.materialId,
+            currentDepartmentId: originDepartmentId,
             stockSize: part.stockSize ?? null,
             cutLength: part.cutLength ?? null,
             notes: part.notes ?? undefined,
@@ -748,28 +772,29 @@ export async function convertQuoteToOrder({
         })) ?? [];
 
     const allSelections = [...quotePartSelections, ...legacySelections];
-    const chargeSelections = allSelections.filter(
-      (entry: any) =>
-        entry.orderPartId &&
-        entry.selection.addon?.departmentId &&
-        entry.selection.addon?.affectsPrice !== false
-    );
+    const chargeData = buildOrderChargeEntriesFromQuoteData({
+      orderId: order.id,
+      selections: allSelections,
+      customAmounts: metadata?.customAmounts,
+      customAmountPartId: orderParts[0]?.id ?? null,
+      fallbackDepartmentId: originDepartmentId,
+    });
 
-    if (chargeSelections.length) {
+    if (chargeData.length) {
       await Promise.all(
-        chargeSelections.map(({ selection, orderPartId }: any, index: number) =>
+        chargeData.map((charge) =>
           tx.orderCharge.create({
             data: {
-              orderId: order.id,
-              partId: orderPartId!,
-              departmentId: selection.addon?.departmentId ?? '',
-              addonId: selection.addonId,
-              kind: 'ADDON',
-              name: selection.addon?.name ?? 'Add-on',
-              description: selection.notes ?? null,
-              quantity: new Prisma.Decimal(selection.units ?? 0),
-              unitPrice: new Prisma.Decimal(selection.rateCents ?? 0),
-              sortOrder: index,
+              orderId: charge.orderId,
+              partId: charge.partId,
+              departmentId: charge.departmentId,
+              addonId: charge.addonId,
+              kind: charge.kind,
+              name: charge.name,
+              description: charge.description,
+              quantity: new Prisma.Decimal(charge.quantity),
+              unitPrice: new Prisma.Decimal(charge.unitPriceCents),
+              sortOrder: charge.sortOrder,
             },
           })
         )

--- a/src/modules/quotes/quotes.schema.ts
+++ b/src/modules/quotes/quotes.schema.ts
@@ -64,6 +64,7 @@ export const QuoteCreate = z.object({
   parts: z.array(QuotePartInput).default([]),
   vendorItems: z.array(QuoteVendorItemInput).default([]),
   attachments: z.array(QuoteAttachmentInput).default([]),
+  originDepartmentId: z.string().trim().min(1).max(100).optional(),
   partPricing: z
     .array(
       z.object({
@@ -71,6 +72,14 @@ export const QuoteCreate = z.object({
         partNumber: z.string().trim().max(200).optional(),
         priceCents: z.coerce.number().int().min(0),
         pricingMode: PricingMode.default('LOT_TOTAL'),
+      })
+    )
+    .optional(),
+  customAmounts: z
+    .array(
+      z.object({
+        title: z.string().trim().min(1).max(200),
+        amountCents: z.coerce.number().int().min(0),
       })
     )
     .optional(),

--- a/src/modules/quotes/quotes.service.ts
+++ b/src/modules/quotes/quotes.service.ts
@@ -1,8 +1,11 @@
 import 'server-only';
 
 import { BUSINESS_PREFIX_BY_CODE, type BusinessCode } from '@/lib/businesses';
+import { sumQuoteCustomAmountsCents } from '@/lib/quote-metadata';
 import type { QuoteCreateInput } from '@/modules/quotes/quotes.schema';
 import type { QuoteApprovalMetadata } from '@/lib/quote-metadata';
+import { calculatePartLotTotal } from '@/modules/pricing/part-pricing';
+import { calculatePartPricingSummaryTotalsCents, calculateWorkItemsSubtotalCents } from '@/modules/pricing/work-item-pricing';
 import {
   createQuoteWithDetails,
   deleteQuoteById,
@@ -96,6 +99,57 @@ export function calculatePricedAddonTotal(
   }, 0);
 }
 
+export function calculateQuoteEstimateTotalCents({
+  basePriceCents,
+  vendorTotalCents,
+  parts,
+  partPricing,
+  addonMap,
+  customAmountsCents,
+}: {
+  basePriceCents: number;
+  vendorTotalCents: number;
+  parts: QuoteCreateInput['parts'];
+  partPricing: QuoteCreateInput['partPricing'];
+  addonMap: Map<string, { rateCents: number; affectsPrice: boolean }>;
+  customAmountsCents: number;
+}) {
+  const pricingSummaryTotals = calculatePartPricingSummaryTotalsCents({
+    parts: (parts ?? []).map((part, index) => {
+      const workItemsSubtotalCents = calculateWorkItemsSubtotalCents({
+        selections: (part.addonSelections ?? []).map((selection) => ({
+          addonId: selection.addonId,
+          units: selection.units ?? 0,
+        })),
+        itemsById: addonMap,
+      });
+      const pricingEntry = partPricing?.[index];
+      const enteredPriceCents = Math.max(0, pricingEntry?.priceCents ?? 0);
+      const quantity = Math.max(1, part.quantity ?? 1);
+      return {
+        workItemsSubtotalCents,
+        partPricingSubtotalCents:
+          enteredPriceCents > 0
+            ? calculatePartLotTotal({
+                enteredPriceCents,
+                quantity,
+                pricingMode: pricingEntry?.pricingMode === 'PER_UNIT' ? 'PER_UNIT' : 'LOT_TOTAL',
+              })
+            : 0,
+        hasPartPricingOverride: enteredPriceCents > 0,
+      };
+    }),
+  });
+
+  return (
+    basePriceCents +
+    vendorTotalCents +
+    pricingSummaryTotals.addonsAndLaborCents +
+    pricingSummaryTotals.partPricingCents +
+    customAmountsCents
+  );
+}
+
 export async function prepareQuoteComponents(
   input: QuoteCreateInput,
   options?: { existingQuoteNumber?: string }
@@ -150,17 +204,6 @@ export async function prepareQuoteComponents(
     addonSelectionsByPart.set(selection.partIndex, [...existing, entry]);
   }
 
-  const addonsTotalCents = calculatePricedAddonTotal(
-    addonSelectionsInput.map(({ item }) => {
-      const addon = addonMap.get(item.addonId)!;
-      return {
-        units: typeof item.units === 'number' ? item.units : 0,
-        rateCents: addon.rateCents,
-        affectsPrice: addon.affectsPrice,
-      };
-    })
-  );
-
   const vendorItems = vendorItemsInput.map((item) => {
     const vendor = item.vendorId ? vendorMap.get(item.vendorId) : undefined;
     const basePriceCents = item.basePriceCents ?? 0;
@@ -181,7 +224,40 @@ export async function prepareQuoteComponents(
 
   const vendorTotalCents = vendorItems.reduce((sum, item) => sum + item.finalPriceCents, 0);
   const basePriceCents = input.basePriceCents ?? 0;
-  const totalCents = basePriceCents + vendorTotalCents + addonsTotalCents;
+  const customAmountsCents = sumQuoteCustomAmountsCents(input.customAmounts);
+  const addonsTotalCents = calculatePartPricingSummaryTotalsCents({
+    parts: parts.map((part, index) => {
+      const workItemsSubtotalCents = calculateWorkItemsSubtotalCents({
+        selections: (part.addonSelections ?? []).map((selection) => ({
+          addonId: selection.addonId,
+          units: selection.units ?? 0,
+        })),
+        itemsById: addonMap,
+      });
+      const partPricingEntry = input.partPricing?.[index];
+      const enteredPriceCents = Math.max(0, partPricingEntry?.priceCents ?? 0);
+      return {
+        workItemsSubtotalCents,
+        partPricingSubtotalCents:
+          enteredPriceCents > 0
+            ? calculatePartLotTotal({
+                enteredPriceCents,
+                quantity: Math.max(1, part.quantity ?? 1),
+                pricingMode: partPricingEntry?.pricingMode === 'PER_UNIT' ? 'PER_UNIT' : 'LOT_TOTAL',
+              })
+            : 0,
+        hasPartPricingOverride: enteredPriceCents > 0,
+      };
+    }),
+  }).addonsAndLaborCents;
+  const totalCents = calculateQuoteEstimateTotalCents({
+    basePriceCents,
+    vendorTotalCents,
+    parts,
+    partPricing: input.partPricing,
+    addonMap,
+    customAmountsCents,
+  });
 
   const providedQuoteNumber = input.quoteNumber?.trim();
   let quoteNumber: string;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -2736,3 +2736,41 @@ Commands run:
 - Next if we continue here: fix the repo-wide type-check baseline or split the remaining UI polish into smaller validation-targeted passes.
 
 
+# tasks/todo.md - Session Plan + Verification
+
+## Session Metadata
+- Date: 2026-04-14
+- Agent: Codex GPT-5
+- Task ID: Quote origin department + per-foot pricing + custom quote amount
+- Goal: Let admins assign a quote origin/default department, support per-foot pricing for paint add-ons/labor/checklist items, and add titled custom quote amounts that flow through quote review and quote-to-order/invoice-related charge generation.
+
+## Dependency Validation
+- [x] Reviewed `AGENTS.md`, `docs/AGENT_CONTEXT.md`, `PROGRESS_LOG.md`, `docs/AGENT_HANDOFF.md`, `tasks/todo.md`, `tasks/lessons.md`, and `docs/AGENT_TASK_BOARD.md` before implementation.
+- [x] Validated the current gap in code:
+  - quote review totals already compute part-pricing overrides in the client, but quote prep/conversion still only persist the older pricing fields,
+  - add-on pricing currently assumes only `HOURLY` or `FLAT`,
+  - quote conversion currently stamps order charges directly from quote add-on selections and add-on department/rate snapshots, so new quote pricing fields must survive conversion rather than staying UI-only.
+
+## Plan First
+- [x] Extend the quote/add-on persistence contracts for origin department, per-foot pricing metadata, and titled custom quote amounts with minimal schema changes.
+- [x] Update shared quote/pricing helpers and quote-to-order conversion so saved quote data maps cleanly into order charges and downstream print/invoice data.
+- [x] Update the quote editor UI/review step to expose origin department, per-foot unit entry, and titled custom amount rows.
+- [x] Run targeted verification and refresh continuity docs plus any lesson learned if needed.
+
+## Verification Checklist
+- [x] No Prisma migration required: reused existing string-based add-on rate fields plus quote metadata for origin department and custom amount persistence.
+- [x] `npx eslint --ext .ts,.tsx -- "src/app/admin/addons/client.tsx" "src/app/admin/addons/page.tsx" "src/app/admin/quotes/QuoteEditor.tsx" "src/app/admin/quotes/[id]/page.tsx" "src/app/admin/quotes/[id]/print/page.tsx" "src/app/orders/new/page.tsx" "src/components/AvailableItemsLibrary.tsx" "src/components/AssignedItemsPanel.tsx" "src/lib/zod.ts" "src/lib/quote-metadata.ts" "src/modules/pricing/work-item-pricing.ts" "src/modules/pricing/__tests__/work-item-pricing.test.ts" "src/modules/quotes/quotes.schema.ts" "src/modules/quotes/quotes.service.ts" "src/modules/quotes/quotes.repo.ts" "src/modules/quotes/quote-work-items.ts" "src/modules/quotes/__tests__/quote-work-items.test.ts" "src/modules/quotes/__tests__/quote-totals.test.ts" "src/app/api/admin/quotes/[id]/route.ts"`
+- [x] `npm run test -- src/modules/pricing/__tests__/work-item-pricing.test.ts src/modules/quotes/__tests__/quote-work-items.test.ts src/modules/quotes/__tests__/quote-totals.test.ts` *(outside-sandbox rerun after Windows `spawn EPERM` from sandboxed esbuild startup)*
+
+## Review + Results
+- Add-ons now support `PER_FOOT` alongside `HOURLY` and `FLAT`, and the shared pricing/UI helpers now label rates and units consistently as hours, feet, or quantity.
+- Quote review now exposes:
+  - an optional origin/default department for conversion,
+  - titled custom amount rows,
+  - updated totals that include custom amounts and preserve part-pricing override behavior.
+- Quote persistence now stores origin department and custom amounts in quote metadata without introducing a new DB schema surface.
+- Quote detail/print views now include custom amount totals and clearer unit labels for quoted add-ons.
+- Quote conversion now:
+  - starts converted order parts in the quote origin department when one is set,
+  - converts custom quote amounts into non-checklist `CUSTOM` order charges on the first part using the origin/fallback department,
+  - keeps the existing add-on/checklist conversion flow intact.


### PR DESCRIPTION
## Summary
- add quote origin/default department selection so paint-origin quotes can start in the right department when converted
- support `PER_FOOT` add-on/labor/checklist pricing throughout quote creation, review, detail, print, and downstream order flows
- add titled custom quote amounts in price review and convert them into persisted `CUSTOM` order charges during quote conversion

## Why
Paint-only quotes may never touch fab or machining, and one-off quote adjustments need to survive quote conversion and invoice/order-charge generation instead of being lost.

## Validation
- `npx eslint --ext .ts,.tsx -- "src/app/admin/addons/client.tsx" "src/app/admin/addons/page.tsx" "src/app/admin/quotes/QuoteEditor.tsx" "src/app/admin/quotes/[id]/page.tsx" "src/app/admin/quotes/[id]/print/page.tsx" "src/app/orders/new/page.tsx" "src/components/AvailableItemsLibrary.tsx" "src/components/AssignedItemsPanel.tsx" "src/lib/zod.ts" "src/lib/quote-metadata.ts" "src/modules/pricing/work-item-pricing.ts" "src/modules/pricing/__tests__/work-item-pricing.test.ts" "src/modules/quotes/quotes.schema.ts" "src/modules/quotes/quotes.service.ts" "src/modules/quotes/quotes.repo.ts" "src/modules/quotes/quote-work-items.ts" "src/modules/quotes/__tests__/quote-work-items.test.ts" "src/modules/quotes/__tests__/quote-totals.test.ts" "src/app/api/admin/quotes/[id]/route.ts"`
- `npm run test -- src/modules/pricing/__tests__/work-item-pricing.test.ts src/modules/quotes/__tests__/quote-work-items.test.ts src/modules/quotes/__tests__/quote-totals.test.ts` (rerun outside the sandbox after a local `spawn EPERM` during the first attempt)

## Notes
- local `prisma/prisma/dev.db` changes were intentionally left out of this PR